### PR TITLE
Remove unused import from room routes

### DIFF
--- a/src/routes/roomRoutes.ts
+++ b/src/routes/roomRoutes.ts
@@ -1,6 +1,5 @@
 import express from 'express';
 import * as RoomController from '../controllers/roomController';
-import { spawn, exec } from 'child_process';
 
 const router = express.Router();
 


### PR DESCRIPTION
## Summary
- drop unused `spawn, exec` import from `roomRoutes`

## Testing
- `npm run build` *(fails: cannot find module 'express')*

------
https://chatgpt.com/codex/tasks/task_e_685b93cd02b883328d05bb206f5b1edb