### PR TITLE
Fix room controller response handling

### DIFF
--- a/src/controllers/roomController.ts
+++ b/src/controllers/roomController.ts
@@ -24,20 +24,29 @@ export const getRooms: RequestHandler = async (_req, res) => {
   }
 };
 
-export const deleteRoom: RequestHandler = async (req, res) => {
+export const deleteRoom: RequestHandler = async (
+  req,
+  res
+): Promise<void> => {
   try {
     const roomId = Number(req.params.roomId);
     if (isNaN(roomId)) {
-      return res.status(400).json({ error: 'Invalid roomId' });
+      res.status(400).json({ error: 'Invalid roomId' });
+      return;
     }
     await RoomService.deleteRoom(roomId);
     res.json({ message: 'Room deleted' });
+    return;
   } catch (error) {
     res.status(500).json({ error: 'Room not found or error' });
+    return;
   }
 };
 
-export const leaveRoom: RequestHandler = async (req, res) => {
+export const leaveRoom: RequestHandler = async (
+  req,
+  res
+): Promise<void> => {
   try {
   
       // Lấy dữ liệu từ body
@@ -45,45 +54,58 @@ export const leaveRoom: RequestHandler = async (req, res) => {
 
     // Kiểm tra nếu roomId hoặc userId không hợp lệ
     if (isNaN(roomId) || isNaN(userId)) {
-      return res.status(400).json({ error: 'Invalid roomId or userId' });
+      res.status(400).json({ error: 'Invalid roomId or userId' });
+      return;
     }
     // Gọi service để xóa người dùng khỏi phòng
     await RoomService.leaveRoom(roomId, userId);
 
     // Trả về kết quả thành công
     res.json({ message: 'User left the room successfully' });
+    return;
   } catch (error) {
     console.error('💥 Lỗi trong leaveRoom:', error);
     res.status(500).json({ error: error.message || 'Room not found or error' });
+    return;
   }
 };
 
-export const joinRoom: RequestHandler = async (req, res) => {
+export const joinRoom: RequestHandler = async (
+  req,
+  res
+): Promise<void> => {
   try {
      // Lấy dữ liệu từ body
      const { roomId, userId } = req.body;
 
     // Kiểm tra nếu roomId hoặc userId không hợp lệ
     if (isNaN(roomId) || isNaN(userId)) {
-      return res.status(400).json({ error: 'Invalid roomId or userId' });
+      res.status(400).json({ error: 'Invalid roomId or userId' });
+      return;
     }
     await RoomService.joinRoom(roomId, userId);
 
     // Trả về kết quả thành công
     res.json({ message: 'User join the room successfully' });
+    return;
   } catch (error) {
     console.error('💥 Lỗi :', error);
     res.status(500).json({ error: error.message || 'Room not found or error' });
+    return;
   }
 };
 
-export const getUserRoomsController: RequestHandler = async (req, res) => {
+export const getUserRoomsController: RequestHandler = async (
+  req,
+  res
+): Promise<void> => {
   try {
     const roomId = Number(req.query.roomId);   
 
     // Kiểm tra nếu roomId không hợp lệ
     if (isNaN(roomId)) {
-      return res.status(400).json({ error: 'Invalid roomId' });
+      res.status(400).json({ error: 'Invalid roomId' });
+      return;
     }
 
     // Gọi service để lấy danh sách người dùng trong phòng
@@ -91,8 +113,10 @@ export const getUserRoomsController: RequestHandler = async (req, res) => {
 
     // Trả về danh sách người dùng
     res.json(users);
+    return;
   } catch (error) {
     console.error('💥 Lỗi trong getUserRoomsController:', error);
     res.status(500).json({ error: error.message || 'Internal server error' });
+    return;
   }
 };


### PR DESCRIPTION
## Summary
- ensure `deleteRoom`, `leaveRoom`, `joinRoom`, and `getUserRoomsController` return `Promise<void>`
- send response then `return` for all error and success cases

## Testing
- `npm run build` *(fails: Cannot find module 'express' or its corresponding type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_685b9b08b9f483329e232586f89538aa