### PR TITLE
Add inventory system

### DIFF
--- a/ReadMe
+++ b/ReadMe
@@ -2,8 +2,9 @@ load lại databse
 npx prisma generate  
 đồng bộ file data vs database thực tế
 npx prisma db push
-xoa het data cu 
+xoa het data cu
 npx prisma db push --force-reset
+npx ts-node prisma/seed.ts # thêm dữ liệu mẫu
 
 build file js sau đó up lên server thư mục dist và prisma nếu có thay đổi database
 npx tsc 
@@ -13,3 +14,7 @@ pm2 list
 pm2 restart BanCuLi
 pm2 stop BanCuLi
 pm2 delete BanCuLi
+
+API:
+GET /api/items - Danh sách vật phẩm
+GET /api/players/:id/inventory - Túi đồ người chơi

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -28,6 +28,7 @@ model Player {
   TalentPoint  Int?
   IdAccount    String
   roomUsers   RoomUser[]
+  playerItems PlayerItem[]
 }
 
 
@@ -51,4 +52,29 @@ model RoomUser {
   player  Player  @relation(fields: [userId], references: [id]) // Quan hệ với bảng Player
   room    Room    @relation(fields: [roomId], references: [id]) // Quan hệ với bảng Room
    @@unique([roomId, userId]) // Đảm bảo mỗi người dùng chỉ có thể tham gia một phòng một lần
+}
+
+model Item {
+  id          Int     @id @default(autoincrement())
+  name        String
+  description String
+  level       Int
+  typeGid     Int     @map("Type_Gid")
+  price       Int
+  isLevelUp   Boolean @map("is_Level_Up")
+  isOpen      Boolean
+  locationGid Int     @map("Location_Gid")
+  playerItems PlayerItem[]
+}
+
+model PlayerItem {
+  id       Int  @id @default(autoincrement())
+  playerId Int
+  itemId   Int
+  quantity Int  @default(1)
+
+  player Player @relation(fields: [playerId], references: [id])
+  item   Item   @relation(fields: [itemId], references: [id])
+
+  @@unique([playerId, itemId])
 }

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -1,0 +1,38 @@
+import { PrismaClient } from '@prisma/client';
+
+const prisma = new PrismaClient();
+
+async function main() {
+  const items = [
+    { name: 'Potion', description: 'Restore health', level: 1, typeGid: 1, price: 50, isLevelUp: false, isOpen: true, locationGid: 0 },
+    { name: 'Elixir', description: 'Restore mana', level: 1, typeGid: 2, price: 75, isLevelUp: false, isOpen: true, locationGid: 0 }
+  ];
+
+  for (const data of items) {
+    await prisma.item.upsert({
+      where: { id: data.typeGid },
+      update: {},
+      create: data
+    });
+  }
+
+  const player = await prisma.player.findFirst();
+  if (player) {
+    const firstItem = await prisma.item.findFirst();
+    if (firstItem) {
+      await prisma.playerItem.upsert({
+        where: { playerId_itemId: { playerId: player.id, itemId: firstItem.id } },
+        update: { quantity: 1 },
+        create: { playerId: player.id, itemId: firstItem.id, quantity: 1 }
+      });
+    }
+  }
+}
+
+main()
+  .catch((e) => {
+    console.error(e);
+  })
+  .finally(async () => {
+    await prisma.$disconnect();
+  });

--- a/src/app.ts
+++ b/src/app.ts
@@ -2,10 +2,12 @@
 import express from 'express';
 import playerRoutes from './routes/playerRoutes';
 import roomRoutes from './routes/roomRoutes';
+import itemRoutes from './routes/itemRoutes';
 
 const app = express();
 
 app.use(express.json());
 app.use('/api', playerRoutes);
 app.use('/api', roomRoutes); // Assuming you have roomRoutes defined in a similar way
+app.use('/api', itemRoutes);
 export default app;

--- a/src/controllers/itemController.ts
+++ b/src/controllers/itemController.ts
@@ -1,0 +1,11 @@
+import { Request, Response } from 'express';
+import * as ItemService from '../services/itemService';
+
+export const getItems = async (_req: Request, res: Response) => {
+  try {
+    const items = await ItemService.getAllItems();
+    res.json(items);
+  } catch (error: any) {
+    res.status(500).json({ message: error.message });
+  }
+};

--- a/src/controllers/playerController.ts
+++ b/src/controllers/playerController.ts
@@ -1,6 +1,7 @@
 // src/controllers/playerController.ts
 import { Request, Response } from 'express';
 import { getPlayerByAccountId, getPlayerByListId } from '../services/playerService';
+import { getInventoryByPlayer } from '../services/itemService';
 
 export const getPlayerController = async (req: Request, res: Response) => {
   try {
@@ -20,9 +21,22 @@ export const getPlayerController = async (req: Request, res: Response) => {
  
 export const getPlayerByIdsController = async (req: Request, res: Response) => {
   try {
-    let ids = req.body.ids;  
+    let ids = req.body.ids;
     const players = await getPlayerByListId(ids);
     res.json({ players });
+  } catch (error: any) {
+    res.status(500).json({ message: error.message });
+  }
+};
+
+export const getInventoryController = async (req: Request, res: Response) => {
+  try {
+    const id = Number(req.params.id);
+    if (isNaN(id)) {
+      return res.status(400).json({ message: 'Invalid player id' });
+    }
+    const inventory = await getInventoryByPlayer(id);
+    res.json(inventory);
   } catch (error: any) {
     res.status(500).json({ message: error.message });
   }

--- a/src/routes/itemRoutes.ts
+++ b/src/routes/itemRoutes.ts
@@ -1,0 +1,8 @@
+import { Router } from 'express';
+import * as ItemController from '../controllers/itemController';
+
+const router = Router();
+
+router.get('/items', ItemController.getItems);
+
+export default router;

--- a/src/routes/playerRoutes.ts
+++ b/src/routes/playerRoutes.ts
@@ -5,6 +5,7 @@ const router = Router();
 
 router.get('/player/:id', PlayerController.getPlayerController);
 router.post('/player/by-list-id', PlayerController.getPlayerByIdsController);
+router.get('/players/:id/inventory', PlayerController.getInventoryController);
  
 
 // router.post('/player/:id/experience', updateExperienceController);

--- a/src/services/itemService.ts
+++ b/src/services/itemService.ts
@@ -1,0 +1,12 @@
+import prisma from '../models/prismaClient';
+
+export const getAllItems = async () => {
+  return prisma.item.findMany();
+};
+
+export const getInventoryByPlayer = async (playerId: number) => {
+  return prisma.playerItem.findMany({
+    where: { playerId },
+    include: { item: true }
+  });
+};


### PR DESCRIPTION
## Summary
- define new `Item` and `PlayerItem` models
- seed sample items and inventory
- expose item and inventory APIs
- wire routes up in the express app
- document seed command and endpoints

## Testing
- `npx prisma generate` *(fails: 403 Forbidden)*
- `npx prisma db push` *(fails: 403 Forbidden)*
- `npm run build` *(fails: cannot find module declarations)*

------
https://chatgpt.com/codex/tasks/task_e_685ba1290d0083329fed57ee8b954032