### PR TITLE
Fix inventory route handler type

### DIFF
--- a/src/controllers/playerController.ts
+++ b/src/controllers/playerController.ts
@@ -1,5 +1,5 @@
 // src/controllers/playerController.ts
-import { Request, Response } from 'express';
+import { Request, Response, RequestHandler } from 'express';
 import { getPlayerByAccountId, getPlayerByListId } from '../services/playerService';
 import { getInventoryByPlayer } from '../services/itemService';
 
@@ -29,16 +29,22 @@ export const getPlayerByIdsController = async (req: Request, res: Response) => {
   }
 };
 
-export const getInventoryController = async (req: Request, res: Response) => {
+export const getInventoryController: RequestHandler = async (
+  req,
+  res
+): Promise<void> => {
   try {
     const id = Number(req.params.id);
     if (isNaN(id)) {
-      return res.status(400).json({ message: 'Invalid player id' });
+      res.status(400).json({ message: 'Invalid player id' });
+      return;
     }
     const inventory = await getInventoryByPlayer(id);
     res.json(inventory);
+    return;
   } catch (error: any) {
     res.status(500).json({ message: error.message });
+    return;
   }
 };
 

--- a/src/routes/playerRoutes.ts
+++ b/src/routes/playerRoutes.ts
@@ -1,11 +1,12 @@
 // src/routes/playerRoutes.ts
 import { Router } from 'express';
 import * as PlayerController from '../controllers/playerController';
+import { getInventoryController } from '../controllers/playerController';
 const router = Router();
 
 router.get('/player/:id', PlayerController.getPlayerController);
 router.post('/player/by-list-id', PlayerController.getPlayerByIdsController);
-router.get('/players/:id/inventory', PlayerController.getInventoryController);
+router.get('/players/:id/inventory', getInventoryController);
  
 
 // router.post('/player/:id/experience', updateExperienceController);


### PR DESCRIPTION
## Summary
- type `getInventoryController` as RequestHandler
- use `Promise<void>` return signature
- apply handler directly in player routes

## Testing
- `npm run build` *(fails: Cannot find module 'express' or its corresponding type declarations)*
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_685bae1bad20833282dc01947e1aae92