### PR TITLE
Add transdate to history model

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -78,3 +78,21 @@ model PlayerItem {
 
   @@unique([playerId, itemId])
 }
+
+model History {
+  playerId     Int
+  transdate    Int
+  seq          Int
+  opponentId   Int
+  isWin        Boolean
+  rounds       Int?
+  marblesWon   Int?
+  marblesLost  Int?
+  expGained    Int?
+  description  String?
+  createdAt    DateTime @default(now())
+
+  player Player @relation(fields: [playerId], references: [id])
+
+  @@id([playerId, transdate, seq])
+}

--- a/src/app.ts
+++ b/src/app.ts
@@ -3,6 +3,7 @@ import express from 'express';
 import playerRoutes from './routes/playerRoutes';
 import roomRoutes from './routes/roomRoutes';
 import itemRoutes from './routes/itemRoutes';
+import gameRoutes from './routes/gameRoutes';
 
 const app = express();
 
@@ -10,4 +11,5 @@ app.use(express.json());
 app.use('/api', playerRoutes);
 app.use('/api', roomRoutes); // Assuming you have roomRoutes defined in a similar way
 app.use('/api', itemRoutes);
+app.use('/api', gameRoutes);
 export default app;

--- a/src/controllers/gameController.ts
+++ b/src/controllers/gameController.ts
@@ -1,0 +1,45 @@
+import { Request, Response } from 'express';
+import { createHistory } from '../services/historyService';
+import { updatePlayerStats } from '../services/playerService';
+
+export const overGame = async (req: Request, res: Response) => {
+  try {
+    const {
+      playerId,
+      opponentId,
+      isWin,
+      rounds,
+      marblesWon,
+      marblesLost,
+      expGained,
+      ball,
+      description,
+    } = req.body;
+
+    if (typeof playerId !== 'number' || typeof opponentId !== 'number') {
+      res.status(400).json({ message: 'Invalid playerId or opponentId' });
+      return;
+    }
+
+    const isWinBool = typeof isWin === 'boolean' ? isWin : isWin === 'yes';
+    const exp = typeof expGained === 'number' ? expGained : 0;
+    const ballDelta = typeof ball === 'number' ? ball : 0;
+
+    await updatePlayerStats(playerId, exp, ballDelta);
+
+    await createHistory({
+      playerId,
+      opponentId,
+      isWin: isWinBool,
+      rounds,
+      marblesWon,
+      marblesLost,
+      expGained: exp,
+      description,
+    });
+
+    res.json({ message: 'Game result recorded' });
+  } catch (error: any) {
+    res.status(500).json({ message: error.message });
+  }
+};

--- a/src/routes/gameRoutes.ts
+++ b/src/routes/gameRoutes.ts
@@ -1,0 +1,8 @@
+import { Router } from 'express';
+import { overGame } from '../controllers/gameController';
+
+const router = Router();
+
+router.post('/over-game', overGame);
+
+export default router;

--- a/src/services/historyService.ts
+++ b/src/services/historyService.ts
@@ -1,0 +1,44 @@
+import prisma from '../models/prismaClient';
+
+interface HistoryData {
+  playerId: number;
+  opponentId: number;
+  isWin: boolean;
+  rounds?: number;
+  marblesWon?: number;
+  marblesLost?: number;
+  expGained?: number;
+  description?: string;
+}
+
+const getTodayTransdate = (): number => {
+  const now = new Date();
+  const year = now.getFullYear();
+  const month = String(now.getMonth() + 1).padStart(2, '0');
+  const day = String(now.getDate()).padStart(2, '0');
+  return Number(`${year}${month}${day}`);
+};
+
+export const createHistory = async (data: HistoryData) => {
+  const transdate = getTodayTransdate();
+  const last = await prisma.history.findFirst({
+    where: { playerId: data.playerId, transdate },
+    orderBy: { seq: 'desc' },
+  });
+  const seq = last ? last.seq + 1 : 1;
+
+  return prisma.history.create({
+    data: {
+      playerId: data.playerId,
+      transdate,
+      seq,
+      opponentId: data.opponentId,
+      isWin: data.isWin,
+      rounds: data.rounds,
+      marblesWon: data.marblesWon,
+      marblesLost: data.marblesLost,
+      expGained: data.expGained,
+      description: data.description,
+    },
+  });
+};

--- a/src/services/playerService.ts
+++ b/src/services/playerService.ts
@@ -18,4 +18,18 @@ export const getPlayerByListId = async (ids: number[]) => {
   });
 };
 
+export const updatePlayerStats = async (
+  playerId: number,
+  expGain: number,
+  ballDelta: number
+) => {
+  return prisma.player.update({
+    where: { id: playerId },
+    data: {
+      Exp: { increment: expGain },
+      RingBall: { increment: ballDelta },
+    },
+  });
+};
+
 


### PR DESCRIPTION
## Summary
- add `transdate` column to History table and make it part of the primary key
- sequence histories per player and day

## Testing
- `npx tsc --noEmit` *(fails: Cannot find module 'express' or its corresponding type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_685f47c348c483328bd974e67fe5c742