### PR TITLE
Fix relation for history and clean service

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -29,6 +29,7 @@ model Player {
   IdAccount    String
   roomUsers   RoomUser[]
   playerItems PlayerItem[]
+  histories   History[]
 }
 
 

--- a/src/services/historyService.ts
+++ b/src/services/historyService.ts
@@ -1,6 +1,6 @@
 import prisma from '../models/prismaClient';
 
-interface HistoryData {
+export interface HistoryData {
   playerId: number;
   opponentId: number;
   isWin: boolean;
@@ -11,9 +11,6 @@ interface HistoryData {
   description?: string;
 }
 
-export const createHistory = async (data: HistoryData) => {
-  const last = await prisma.history.findFirst({
-    where: { playerId: data.playerId },
 const getTodayTransdate = (): number => {
   const now = new Date();
   const year = now.getFullYear();


### PR DESCRIPTION
## Summary
- add `histories` relation to `Player` model
- clean up `historyService` implementation

## Testing
- `npm run build` *(fails: Cannot find module 'express')*

------
https://chatgpt.com/codex/tasks/task_e_685f4becabcc833296d69a79d3224379