### PR TITLE
Extend over-game endpoint

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -84,8 +84,13 @@ model History {
   playerId     Int
   transdate    Int
   seq          Int
-  opponentId   Int
-  isWin        Boolean
+  opponentId   Int?
+  isWin        Boolean?
+  turnOrder    Int?
+  typeMatchGid Int?
+  statusWin    Int?
+  mapGame      String?
+  maxPlayer    Int?
   rounds       Int
   marbBet      Int
   marblesWon   Int

--- a/src/controllers/gameController.ts
+++ b/src/controllers/gameController.ts
@@ -4,43 +4,51 @@ import { updatePlayerStats } from '../services/playerService';
 
 export const overGame = async (req: Request, res: Response) => {
   try {
-    const {
-      playerId,
-      opponentId,
-      isWin,
-      rounds,
-      marbBet,
-      marblesWon,
-      marblesLost,
-      expGained,
-      ball,
-      description,
-    } = req.body;
-
-    if (typeof playerId !== 'number' || typeof opponentId !== 'number') {
-      res.status(400).json({ message: 'Invalid playerId or opponentId' });
+    if (!Array.isArray(req.body)) {
+      res.status(400).json({ message: 'Request body must be an array' });
       return;
     }
 
-    const isWinBool = typeof isWin === 'boolean' ? isWin : isWin === 'yes';
-    const exp = typeof expGained === 'number' ? expGained : 0;
-    const ballDelta = typeof ball === 'number' ? ball : 0;
+    for (const entry of req.body) {
+      const {
+        playerId,
+        tunrOrder,
+        typeMatchGid,
+        StatusWin,
+        rounds,
+        MapGame,
+        MaxPlayer,
+        marbBet,
+        marblesWon,
+        marblesLost,
+        expGained,
+        description,
+      } = entry;
 
-    await updatePlayerStats(playerId, exp, ballDelta);
+      if (typeof playerId !== 'number') {
+        continue;
+      }
 
-    await createHistory({
-      playerId,
-      opponentId,
-      isWin: isWinBool,
-      rounds,
-      marbBet,
-      marblesWon,
-      marblesLost,
-      expGained: exp,
-      description,
-    });
+      const exp = typeof expGained === 'number' ? expGained : 0;
+      await updatePlayerStats(playerId, exp, 0);
 
-    res.json({ message: 'Game result recorded' });
+      await createHistory({
+        playerId,
+        turnOrder: tunrOrder,
+        typeMatchGid,
+        statusWin: StatusWin,
+        mapGame: MapGame,
+        maxPlayer: MaxPlayer,
+        rounds,
+        marbBet,
+        marblesWon,
+        marblesLost,
+        expGained: exp,
+        description,
+      });
+    }
+
+    res.json({ message: 'Game results recorded' });
   } catch (error: any) {
     res.status(500).json({ message: error.message });
   }

--- a/src/services/historyService.ts
+++ b/src/services/historyService.ts
@@ -2,8 +2,13 @@ import prisma from '../models/prismaClient';
 
 export interface HistoryData {
   playerId: number;
-  opponentId: number;
-  isWin: boolean;
+  opponentId?: number;
+  isWin?: boolean;
+  turnOrder?: number;
+  typeMatchGid?: number;
+  statusWin?: number;
+  mapGame?: string;
+  maxPlayer?: number;
   rounds?: number;
   marbBet?: number;
   marblesWon?: number;
@@ -35,6 +40,11 @@ export const createHistory = async (data: HistoryData) => {
       seq,
       opponentId: data.opponentId,
       isWin: data.isWin,
+      turnOrder: data.turnOrder,
+      typeMatchGid: data.typeMatchGid,
+      statusWin: data.statusWin,
+      mapGame: data.mapGame,
+      maxPlayer: data.maxPlayer,
       rounds: data.rounds,
       marbBet: data.marbBet,
       marblesWon: data.marblesWon,


### PR DESCRIPTION
## Summary
- extend DB schema with new optional fields for a game result
- collect extra fields when creating history records
- handle an array of `OverGameRequest` objects in the `/over-game` route

## Testing
- `npx tsc --noEmit` *(fails: Cannot find module 'express')*

------
https://chatgpt.com/codex/tasks/task_e_685f60481fa0833295f93c38cbfad9d7