### PR TITLE
Add transno to history records

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -82,9 +82,7 @@ model PlayerItem {
 
 model History {
   playerId     Int
-  transdate    Int
-  seq          Int
-  opponentId   Int?
+  transno      Int
   isWin        Boolean?
   turnOrder    Int?
   typeMatchGid Int?
@@ -98,7 +96,7 @@ model History {
   expGained    Int
   description  String?
   createdAt    DateTime @default(now())
-  
+
   player Player @relation(fields: [playerId], references: [id])
-  @@id([playerId, transdate, seq])
+  @@id([playerId, transno])
 }

--- a/src/services/historyService.ts
+++ b/src/services/historyService.ts
@@ -2,7 +2,6 @@ import prisma from '../models/prismaClient';
 
 export interface HistoryData {
   playerId: number;
-  opponentId?: number;
   isWin?: boolean;
   turnOrder?: number;
   typeMatchGid?: number;
@@ -17,28 +16,25 @@ export interface HistoryData {
   description?: string;
 }
 
-const getTodayTransdate = (): number => {
+const generateTransno = (): number => {
   const now = new Date();
   const year = now.getFullYear();
   const month = String(now.getMonth() + 1).padStart(2, '0');
   const day = String(now.getDate()).padStart(2, '0');
-  return Number(`${year}${month}${day}`);
+  const hour = String(now.getHours()).padStart(2, '0');
+  const minute = String(now.getMinutes()).padStart(2, '0');
+  const second = String(now.getSeconds()).padStart(2, '0');
+  const milli = String(now.getMilliseconds()).padStart(3, '0');
+  return Number(`${year}${month}${day}${hour}${minute}${second}${milli}`);
 };
 
 export const createHistory = async (data: HistoryData) => {
-  const transdate = getTodayTransdate();
-  const last = await prisma.history.findFirst({
-    where: { playerId: data.playerId, transdate },
-    orderBy: { seq: 'desc' },
-  });
-  const seq = last ? last.seq + 1 : 1;
+  const transno = generateTransno();
 
   return prisma.history.create({
     data: {
       playerId: data.playerId,
-      transdate,
-      seq,
-      opponentId: data.opponentId,
+      transno,
       isWin: data.isWin,
       turnOrder: data.turnOrder,
       typeMatchGid: data.typeMatchGid,


### PR DESCRIPTION
## Summary
- modify `History` model to use `transno` instead of opponentId, transdate and seq
- compute `transno` from current timestamp when creating history

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_685f653d92d88332bcdb5229577e27fc