### PR TITLE
Change transno to BigInt

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -82,7 +82,7 @@ model PlayerItem {
 
 model History {
   playerId     Int
-  transno      Int
+  transno      BigInt
   isWin        Boolean?
   turnOrder    Int?
   typeMatchGid Int?

--- a/src/controllers/gameController.ts
+++ b/src/controllers/gameController.ts
@@ -8,7 +8,7 @@ export const overGame = async (req: Request, res: Response) => {
       res.status(400).json({ message: 'Request body must be an array' });
       return;
     }
-const generateTransno = (): number => {
+const generateTransno = (): bigint => {
   const now = new Date();
   const year = now.getFullYear();
   const month = String(now.getMonth() + 1).padStart(2, '0');
@@ -17,7 +17,7 @@ const generateTransno = (): number => {
   const minute = String(now.getMinutes()).padStart(2, '0');
   const second = String(now.getSeconds()).padStart(2, '0');
   const milli = String(now.getMilliseconds()).padStart(3, '0');
-  return Number(`${year}${month}${day}${hour}${minute}${second}${milli}`);
+  return BigInt(`${year}${month}${day}${hour}${minute}${second}${milli}`);
 };
     for (const entry of req.body) {
       const {

--- a/src/services/historyService.ts
+++ b/src/services/historyService.ts
@@ -2,7 +2,7 @@ import prisma from '../models/prismaClient';
 
 export interface HistoryData {
   playerId: number;
-  transno: number; 
+  transno: bigint;
   isWin?: boolean;
   turnOrder?: number;
   typeMatchGid?: number;


### PR DESCRIPTION
## Summary
- use `BigInt` type for `transno` in Prisma schema
- update `HistoryData` interface to use `bigint`
- generate transaction numbers as `bigint`
- (attempt) run Prisma commands

## Testing
- `npx prisma generate`
- `npx prisma migrate dev --name transno-bigint`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_685f958084348332ad9a1908b7504b48