### PR TITLE
Add language and effect player services/controllers

### DIFF
--- a/src/controllers/effectPlayerController.ts
+++ b/src/controllers/effectPlayerController.ts
@@ -1,0 +1,16 @@
+import { Request, Response } from 'express';
+import { getByPlayerId } from '../services/effectPlayerService';
+
+export const getEffectPlayers = async (req: Request, res: Response) => {
+  try {
+    const playerId = Number(req.params.playerId);
+    if (isNaN(playerId)) {
+      res.status(400).json({ message: 'Invalid playerId' });
+      return;
+    }
+    const effects = await getByPlayerId(playerId);
+    res.json(effects);
+  } catch (error: any) {
+    res.status(500).json({ message: error.message });
+  }
+};

--- a/src/controllers/languageController.ts
+++ b/src/controllers/languageController.ts
@@ -1,0 +1,11 @@
+import { Request, Response } from 'express';
+import { getAllLanguages } from '../services/languageService';
+
+export const getLanguages = async (_req: Request, res: Response) => {
+  try {
+    const languages = await getAllLanguages();
+    res.json(languages);
+  } catch (error: any) {
+    res.status(500).json({ message: error.message });
+  }
+};

--- a/src/services/effectPlayerService.ts
+++ b/src/services/effectPlayerService.ts
@@ -1,0 +1,7 @@
+import prisma from '../models/prismaClient';
+
+export const getByPlayerId = async (playerId: number) => {
+  return prisma.effectPlayer.findMany({
+    where: { playerId },
+  });
+};

--- a/src/services/languageService.ts
+++ b/src/services/languageService.ts
@@ -1,0 +1,5 @@
+import prisma from '../models/prismaClient';
+
+export const getAllLanguages = async () => {
+  return prisma.sysMasLanguage.findMany();
+};


### PR DESCRIPTION
## Summary
- add language service and controller
- add effect player service and controller

## Testing
- `npm run build` *(fails: Cannot find module 'express', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68635ae0a4ec83328fc2ce79587d5694