### PR TITLE
Align schema with service layer

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -109,9 +109,10 @@ model SysMasGeneral {
 }
 
 model SysMasLanguage {
-  id      Int    @id @default(autoincrement()) @map("ID")
-  langKey String @map("LANG_KEY")
-  langVal String @map("LANG_VAL")
+  id           Int    @id @default(autoincrement()) @map("ID")
+  code         String @map("CODE")
+  vietnamText  String @map("VIETNAM_TEXT")
+  englishText  String @map("ENGLISH_TEXT")
 
   @@map("SYS_MAS_LANGUAGE")
 }
@@ -120,6 +121,13 @@ model EffectPlayer {
   id       Int    @id @default(autoincrement()) @map("ID")
   playerId Int    @map("PLAYER_ID")
   effectId Int    @map("EFFECT_ID")
+  power       Int     @map("POWER")
+  spin        Int     @map("SPIN")
+  level       Int     @map("LEVEL")
+  isPassive   Boolean @map("Is_Passive")
+  charges     Int     @map("CHARGES")
+  description String  @map("DESCRIPTION")
+  parentId    Int     @map("Parent_Id")
   player   Player @relation(fields: [playerId], references: [id])
 
   @@map("EFFECT_PLAYER")

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -49,7 +49,14 @@ async function main() {
     await (prisma as any).effectPlayer.create({
       data: {
         playerId: player.id,
-        effectName: 'power_skill'
+        effectId: 11000001,
+        power: 10,
+        spin: 5,
+        level: 1,
+        isPassive: false,
+        charges: 3,
+        description: 'Sample effect',
+        parentId: 0,
       }
     });
   }

--- a/src/routes/effectPlayerRoutes.ts
+++ b/src/routes/effectPlayerRoutes.ts
@@ -3,6 +3,6 @@ import * as EffectPlayerController from '../controllers/effectPlayerController';
 
 const router = Router();
 
-router.get('/effect-player/:playerId', EffectPlayerController.getEffectPlayer);
+router.get('/effect-player/:playerId', EffectPlayerController.getEffectPlayers);
 
 export default router;


### PR DESCRIPTION
## Summary
- extend SysMasLanguage table with code, vietnamText, englishText
- expand EffectPlayer table with gameplay fields
- adapt seed script for the new schema
- fix effect player routes to use the proper controller

## Testing
- `npm test` *(fails: no test specified)*
- `npx prisma generate` *(fails: 403 Forbidden - registry.npmjs.org)*

------
https://chatgpt.com/codex/tasks/task_e_68635d740db08332af1cdd3252637c2a