### PR TITLE
Implement level-up API for EffectPlayer

### DIFF
--- a/src/controllers/effectPlayerController.ts
+++ b/src/controllers/effectPlayerController.ts
@@ -1,5 +1,5 @@
 import { Request, Response } from 'express';
-import { getByPlayerId } from '../services/effectPlayerService';
+import { getByPlayerId, levelUpEffectPlayer } from '../services/effectPlayerService';
 
 export const getEffectPlayers = async (req: Request, res: Response) => {
   try {
@@ -12,5 +12,26 @@ export const getEffectPlayers = async (req: Request, res: Response) => {
     res.json(effects);
   } catch (error: any) {
     res.status(500).json({ message: error.message });
+  }
+};
+
+export const levelUpEffect = async (req: Request, res: Response) => {
+  try {
+    const playerId = Number(req.body.playerId);
+    const effectId = Number(req.body.effectId);
+
+    if (isNaN(playerId) || isNaN(effectId)) {
+      res.status(400).json({ message: 'Invalid playerId or effectId' });
+      return;
+    }
+
+    const updated = await levelUpEffectPlayer(playerId, effectId);
+    res.json(updated);
+  } catch (error: any) {
+    if (error.message === 'Không còn điểm TalentPoint để tăng cấp') {
+      res.status(400).json({ message: error.message });
+    } else {
+      res.status(500).json({ message: error.message });
+    }
   }
 };

--- a/src/routes/effectPlayerRoutes.ts
+++ b/src/routes/effectPlayerRoutes.ts
@@ -4,5 +4,6 @@ import * as EffectPlayerController from '../controllers/effectPlayerController';
 const router = Router();
 
 router.get('/effect-player/:playerId', EffectPlayerController.getEffectPlayers);
+router.post('/effect-player/level-up', EffectPlayerController.levelUpEffect);
 
 export default router;

--- a/src/services/effectPlayerService.ts
+++ b/src/services/effectPlayerService.ts
@@ -12,3 +12,38 @@ export const getByPlayerId = async (playerId: number) => {
     },
   });
 };
+
+export const levelUpEffectPlayer = async (
+  playerId: number,
+  effectId: number
+) => {
+  return prisma.$transaction(async (tx) => {
+    const player = await tx.player.findUnique({
+      where: { id: playerId },
+      select: { TalentPoint: true },
+    });
+
+    if (!player) {
+      throw new Error('Player not found');
+    }
+
+    const currentTP = player.TalentPoint ?? 0;
+    if (currentTP <= 0) {
+      throw new Error('Không còn điểm TalentPoint để tăng cấp');
+    }
+
+    await tx.player.update({
+      where: { id: playerId },
+      data: { TalentPoint: currentTP - 1 },
+    });
+
+    await tx.effectPlayer.update({
+      where: { playerId_effectId: { playerId, effectId } },
+      data: {
+        level: { increment: 1 },
+      },
+    });
+
+    return { TalentPoint: currentTP - 1 };
+  });
+};


### PR DESCRIPTION
## Summary
- allow increasing skill levels for a player
- expose new controller and route for upgrading an effect
- deduct a TalentPoint when leveling up an effect

## Testing
- `npm run build` *(fails: Cannot find module 'express' or its corresponding type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_686388415ac083328eabbefc4a3d63af