### PR TITLE
Implement player level progression

### DIFF
--- a/src/services/playerService.ts
+++ b/src/services/playerService.ts
@@ -23,10 +23,61 @@ export const updatePlayerStats = async (
   expGain: number,
   ballDelta: number
 ) => {
+  const player = await prisma.player.findUnique({
+    where: { id: playerId },
+    select: { Exp: true, Level: true },
+  });
+
+  if (!player) {
+    throw new Error('Player not found');
+  }
+
+  const currentExp = player.Exp ?? 0;
+  const currentLevel = player.Level ?? 1;
+
+  const totalExp = currentExp + expGain;
+
+  const levelSteps = [
+    0,
+    100,
+    250,
+    450,
+    700,
+    1000,
+    1350,
+    1750,
+    2200,
+    2700,
+    3250,
+    3850,
+    4500,
+    5200,
+    5950,
+    6750,
+    7600,
+    8500,
+    9450,
+    10450,
+    11500,
+    12600,
+    13750,
+    14950,
+    16200,
+  ];
+
+  let newLevel = currentLevel;
+  for (let i = levelSteps.length - 1; i >= 0; i--) {
+    if (totalExp >= levelSteps[i]) {
+      newLevel = i + 1;
+      break;
+    }
+  }
+
   return prisma.player.update({
     where: { id: playerId },
     data: {
-      Exp: { increment: expGain },
+      Exp: totalExp,
+      Level: newLevel,
       RingBall: { increment: ballDelta },
     },
   });


### PR DESCRIPTION
## Summary
- update `updatePlayerStats` to calculate new level when exp changes

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6864f705e908833294c3e355427f23e4