### PR TITLE
Add player equip endpoint

### DIFF
--- a/ReadMe
+++ b/ReadMe
@@ -19,3 +19,11 @@ pm2 delete BanCuLi
 API:
 GET /api/items - Danh sách vật phẩm
 GET /api/players/:id/inventory - Túi đồ người chơi
+POST /api/player/equip - Trang bị vật phẩm cho người chơi
+
+Body JSON:
+{
+  "playerId": 1,
+  "typeGid": 1,
+  "itemId": 5
+}

--- a/src/controllers/playerController.ts
+++ b/src/controllers/playerController.ts
@@ -1,6 +1,6 @@
 // src/controllers/playerController.ts
 import { Request, Response, RequestHandler } from 'express';
-import { getPlayerByAccountId, getPlayerByListId } from '../services/playerService';
+import { getPlayerByAccountId, getPlayerByListId, equipItem } from '../services/playerService';
 import { getInventoryByPlayer } from '../services/itemService';
 
 export const getPlayerController = async (req: Request, res: Response) => {
@@ -41,6 +41,26 @@ export const getInventoryController: RequestHandler = async (
     }
     const inventory = await getInventoryByPlayer(id);
     res.json(inventory);
+    return;
+  } catch (error: any) {
+    res.status(500).json({ message: error.message });
+    return;
+  }
+};
+
+export const equipItemController: RequestHandler = async (req, res): Promise<void> => {
+  try {
+    const playerId = Number(req.body.playerId);
+    const typeGid = Number(req.body.typeGid);
+    const itemId = Number(req.body.itemId);
+
+    if (isNaN(playerId) || isNaN(typeGid) || isNaN(itemId)) {
+      res.status(400).json({ message: 'Invalid playerId, typeGid or itemId' });
+      return;
+    }
+
+    const updatedPlayer = await equipItem(playerId, typeGid, itemId);
+    res.json(updatedPlayer);
     return;
   } catch (error: any) {
     res.status(500).json({ message: error.message });

--- a/src/routes/playerRoutes.ts
+++ b/src/routes/playerRoutes.ts
@@ -7,6 +7,7 @@ const router = Router();
 router.get('/player/:id', PlayerController.getPlayerController);
 router.post('/player/by-list-id', PlayerController.getPlayerByIdsController);
 router.get('/players/:id/inventory', getInventoryController);
+router.post('/player/equip', PlayerController.equipItemController);
  
 
 // router.post('/player/:id/experience', updateExperienceController);

--- a/src/services/playerService.ts
+++ b/src/services/playerService.ts
@@ -106,4 +106,24 @@ export const updatePlayerStats = async (
   });
 };
 
+export const equipItem = async (
+  playerId: number,
+  typeGid: number,
+  itemId: number
+) => {
+  const data: { Ball?: number; Shirt?: number } = {};
+  if (typeGid === 1) {
+    data.Ball = itemId;
+  } else if (typeGid === 2) {
+    data.Shirt = itemId;
+  } else {
+    throw new Error('Unsupported typeGid');
+  }
+
+  return prisma.player.update({
+    where: { id: playerId },
+    data,
+  });
+};
+
 


### PR DESCRIPTION
## Summary
- implement `equipItem` service to update equipped items
- add controller to handle equip requests
- register `/player/equip` route
- document new endpoint and sample payload

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68667c05bd448332a59fd70b15260fd5