### PR TITLE
Add player item purchase and sale APIs

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -6,6 +6,7 @@ import itemRoutes from './routes/itemRoutes';
 import gameRoutes from './routes/gameRoutes';
 import languageRoutes from './routes/languageRoutes';
 import effectPlayerRoutes from './routes/effectPlayerRoutes';
+import playerItemRoutes from './routes/playerItemRoutes';
 
 const app = express();
 
@@ -16,4 +17,5 @@ app.use('/api', itemRoutes);
 app.use('/api', gameRoutes);
 app.use('/api', languageRoutes);
 app.use('/api', effectPlayerRoutes);
+app.use('/api', playerItemRoutes);
 export default app;

--- a/src/controllers/playerItemController.ts
+++ b/src/controllers/playerItemController.ts
@@ -1,0 +1,36 @@
+import { Request, Response } from 'express';
+import { buyItem, sellItem } from '../services/playerItemService';
+
+export const buyItemController = async (req: Request, res: Response) => {
+  try {
+    const playerId = Number(req.body.playerId);
+    const itemId = Number(req.body.itemId);
+
+    if (isNaN(playerId) || isNaN(itemId)) {
+      res.status(400).json({ message: 'Invalid playerId or itemId' });
+      return;
+    }
+
+    const result = await buyItem(playerId, itemId);
+    res.json(result);
+  } catch (error: any) {
+    res.status(500).json({ message: error.message });
+  }
+};
+
+export const sellItemController = async (req: Request, res: Response) => {
+  try {
+    const id = Number(req.body.id);
+    const price = Number(req.body.price);
+
+    if (isNaN(id) || isNaN(price)) {
+      res.status(400).json({ message: 'Invalid id or price' });
+      return;
+    }
+
+    await sellItem(id, price);
+    res.json({ message: 'Item sold' });
+  } catch (error: any) {
+    res.status(500).json({ message: error.message });
+  }
+};

--- a/src/routes/playerItemRoutes.ts
+++ b/src/routes/playerItemRoutes.ts
@@ -1,0 +1,9 @@
+import { Router } from 'express';
+import { buyItemController, sellItemController } from '../controllers/playerItemController';
+
+const router = Router();
+
+router.post('/player-item/buy', buyItemController);
+router.post('/player-item/sell', sellItemController);
+
+export default router;

--- a/src/services/playerItemService.ts
+++ b/src/services/playerItemService.ts
@@ -1,0 +1,66 @@
+import prisma from '../models/prismaClient';
+
+export const buyItem = async (playerId: number, itemId: number) => {
+  return prisma.$transaction(async (tx) => {
+    const item = await tx.item.findUnique({
+      where: { id: itemId },
+      select: { price: true }
+    });
+
+    if (!item) {
+      throw new Error('Item not found');
+    }
+
+    const player = await tx.player.findUnique({
+      where: { id: playerId },
+      select: { Money: true }
+    });
+
+    if (!player) {
+      throw new Error('Player not found');
+    }
+
+    const currentMoney = player.Money ?? 0;
+    if (currentMoney < item.price) {
+      throw new Error('Not enough money');
+    }
+
+    const playerItem = await tx.playerItem.create({
+      data: {
+        playerId,
+        itemId,
+        level: 1,
+        description: ''
+      }
+    });
+
+    await tx.player.update({
+      where: { id: playerId },
+      data: { Money: { decrement: item.price } }
+    });
+
+    return playerItem;
+  });
+};
+
+export const sellItem = async (id: number, price: number) => {
+  return prisma.$transaction(async (tx) => {
+    const playerItem = await tx.playerItem.findUnique({
+      where: { id },
+      select: { playerId: true }
+    });
+
+    if (!playerItem) {
+      throw new Error('PlayerItem not found');
+    }
+
+    await tx.playerItem.delete({ where: { id } });
+
+    await tx.player.update({
+      where: { id: playerItem.playerId },
+      data: { Money: { increment: price } }
+    });
+
+    return true;
+  });
+};


### PR DESCRIPTION
## Summary
- implement `playerItemService` with `buyItem` and `sellItem`
- add `playerItemController` for new endpoints
- register routes for buying and selling items
- hook new routes into the express app

## Testing
- `npm run build` *(fails: Cannot find module 'express')*

------
https://chatgpt.com/codex/tasks/task_e_68679bbca7748332b0adbeb952367893