### PR TITLE
Add item level-up endpoint

### DIFF
--- a/ReadMe
+++ b/ReadMe
@@ -20,6 +20,7 @@ API:
 GET /api/items - Danh sách vật phẩm
 GET /api/players/:id/inventory - Túi đồ người chơi
 POST /api/player/equip - Trang bị vật phẩm cho người chơi
+POST /api/effect-player/item-level-up - Nâng cấp level của vật phẩm
 
 Body JSON:
 {

--- a/src/controllers/effectPlayerController.ts
+++ b/src/controllers/effectPlayerController.ts
@@ -1,5 +1,6 @@
 import { Request, Response } from 'express';
 import { getByPlayerId, levelUpEffectPlayer } from '../services/effectPlayerService';
+import { levelUpPlayerItem } from '../services/playerItemService';
 
 export const getEffectPlayers = async (req: Request, res: Response) => {
   try {
@@ -35,5 +36,23 @@ export const levelUpEffect = async (req: Request, res: Response) => {
       res.status(500).json({ message: error.message });
     }
  
+  }
+};
+
+export const levelUpItem = async (req: Request, res: Response) => {
+  try {
+    const playerId = Number(req.body.playerId);
+    const itemId = Number(req.body.itemId);
+    const seq = Number(req.body.seq);
+
+    if (isNaN(playerId) || isNaN(itemId) || isNaN(seq)) {
+      res.status(400).json({ message: 'Invalid parameters' });
+      return;
+    }
+
+    const updated = await levelUpPlayerItem(playerId, itemId, seq);
+    res.json(updated);
+  } catch (error: any) {
+    res.status(500).json({ message: error.message });
   }
 };

--- a/src/routes/effectPlayerRoutes.ts
+++ b/src/routes/effectPlayerRoutes.ts
@@ -5,5 +5,6 @@ const router = Router();
 
 router.get('/effect-player/:playerId', EffectPlayerController.getEffectPlayers);
 router.post('/effect-player/level-up', EffectPlayerController.levelUpEffect);
+router.post('/effect-player/item-level-up', EffectPlayerController.levelUpItem);
 
 export default router;

--- a/src/services/playerItemService.ts
+++ b/src/services/playerItemService.ts
@@ -117,3 +117,37 @@ export const sellItem = async (
     return true;
   });
 };
+
+export const levelUpPlayerItem = async (
+  playerId: number,
+  itemId: number,
+  seq: number
+) => {
+  const playerItem = await prisma.playerItem.findUnique({
+    where: {
+      playerId_itemId_seq: {
+        playerId,
+        itemId,
+        seq,
+      },
+    },
+    select: { playerId: true },
+  });
+
+  if (!playerItem) {
+    throw new Error('PlayerItem not found');
+  }
+
+  return prisma.playerItem.update({
+    where: {
+      playerId_itemId_seq: {
+        playerId,
+        itemId,
+        seq,
+      },
+    },
+    data: {
+      level: { increment: 1 },
+    },
+  });
+};


### PR DESCRIPTION
## Summary
- add service to level up a player's item
- expose new controller method under `EffectPlayerController`
- add route `/effect-player/item-level-up`
- document new endpoint

## Testing
- `npx tsc --noEmit` *(fails: Cannot find module 'express', '@prisma/client', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_6868b8923fa483328342292e402f768b