### PR TITLE
Implement achievement system

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -139,3 +139,35 @@ model EffectPlayer {
    @@id([playerId, effectId])
 }
 
+model Reward {
+  id           Int      @id @default(autoincrement())
+  rewardType   String
+  rewardAmount Int
+  itemId       Int?
+  createdAt    DateTime @default(now())
+
+  achievements Achievement[]
+}
+
+model Achievement {
+  id          Int      @id @default(autoincrement())
+  name        String
+  description String?
+  criteria    String?
+  rewardId    Int
+
+  reward            Reward             @relation(fields: [rewardId], references: [id])
+  playerAchievements PlayerAchievement[]
+}
+
+model PlayerAchievement {
+  playerId      Int
+  achievementId Int
+  achievedAt    DateTime @default(now())
+
+  player      Player      @relation(fields: [playerId], references: [id])
+  achievement Achievement @relation(fields: [achievementId], references: [id])
+
+  @@id([playerId, achievementId])
+}
+

--- a/src/app.ts
+++ b/src/app.ts
@@ -8,6 +8,7 @@ import languageRoutes from './routes/languageRoutes';
 import effectPlayerRoutes from './routes/effectPlayerRoutes';
 import playerItemRoutes from './routes/playerItemRoutes';
 import ballPhysicsRoutes from './routes/ballPhysicsRoutes';
+import achievementRoutes from './routes/achievementRoutes';
 
 const app = express();
 
@@ -20,4 +21,5 @@ app.use('/api', languageRoutes);
 app.use('/api', effectPlayerRoutes);
 app.use('/api', playerItemRoutes);
 app.use('/api', ballPhysicsRoutes);
+app.use('/api', achievementRoutes);
 export default app;

--- a/src/controllers/achievementController.ts
+++ b/src/controllers/achievementController.ts
@@ -1,0 +1,54 @@
+import { Request, Response } from 'express';
+import {
+  getAchievementsByPlayer,
+  addPlayerAchievement,
+  claimAchievementReward,
+} from '../services/achievementService';
+
+export const getAchievements = async (req: Request, res: Response) => {
+  try {
+    const playerId = Number(req.params.playerId);
+    if (isNaN(playerId)) {
+      res.status(400).json({ message: 'Invalid playerId' });
+      return;
+    }
+    const achievements = await getAchievementsByPlayer(playerId);
+    res.json(achievements);
+  } catch (error: any) {
+    res.status(500).json({ message: error.message });
+  }
+};
+
+export const completeAchievement = async (req: Request, res: Response) => {
+  try {
+    const playerId = Number(req.body.playerId);
+    const achievementId = Number(req.body.achievementId);
+
+    if (isNaN(playerId) || isNaN(achievementId)) {
+      res.status(400).json({ message: 'Invalid parameters' });
+      return;
+    }
+
+    const result = await addPlayerAchievement(playerId, achievementId);
+    res.json(result);
+  } catch (error: any) {
+    res.status(500).json({ message: error.message });
+  }
+};
+
+export const claimReward = async (req: Request, res: Response) => {
+  try {
+    const playerId = Number(req.body.playerId);
+    const achievementId = Number(req.body.achievementId);
+
+    if (isNaN(playerId) || isNaN(achievementId)) {
+      res.status(400).json({ message: 'Invalid parameters' });
+      return;
+    }
+
+    await claimAchievementReward(playerId, achievementId);
+    res.json({ message: 'Reward claimed' });
+  } catch (error: any) {
+    res.status(500).json({ message: error.message });
+  }
+};

--- a/src/routes/achievementRoutes.ts
+++ b/src/routes/achievementRoutes.ts
@@ -1,0 +1,10 @@
+import { Router } from 'express';
+import * as AchievementController from '../controllers/achievementController';
+
+const router = Router();
+
+router.get('/achievements/:playerId', AchievementController.getAchievements);
+router.post('/achievements/complete', AchievementController.completeAchievement);
+router.post('/achievements/claim', AchievementController.claimReward);
+
+export default router;

--- a/src/services/achievementService.ts
+++ b/src/services/achievementService.ts
@@ -1,0 +1,97 @@
+import prisma from '../models/prismaClient';
+
+export const getAchievementsByPlayer = async (playerId: number) => {
+  const achievements = await prisma.achievement.findMany({
+    include: {
+      reward: true,
+      playerAchievements: {
+        where: { playerId },
+        select: { achievedAt: true },
+      },
+    },
+  });
+
+  return achievements.map((a) => ({
+    id: a.id,
+    name: a.name,
+    description: a.description,
+    criteria: a.criteria,
+    reward: a.reward,
+    achieved: a.playerAchievements.length > 0,
+  }));
+};
+
+export const addPlayerAchievement = async (
+  playerId: number,
+  achievementId: number,
+) => {
+  return prisma.playerAchievement.create({
+    data: { playerId, achievementId },
+  });
+};
+
+export const claimAchievementReward = async (
+  playerId: number,
+  achievementId: number,
+) => {
+  return prisma.$transaction(async (tx) => {
+    const achievement = await tx.achievement.findUnique({
+      where: { id: achievementId },
+      include: { reward: true },
+    });
+
+    if (!achievement || !achievement.reward) {
+      throw new Error('Achievement not found');
+    }
+
+    const pa = await tx.playerAchievement.findUnique({
+      where: {
+        playerId_achievementId: { playerId, achievementId },
+      },
+    });
+
+    if (!pa) {
+      throw new Error('Player has not completed this achievement');
+    }
+
+    if (achievement.reward.rewardType === 'money') {
+      await tx.player.update({
+        where: { id: playerId },
+        data: { Money: { increment: achievement.reward.rewardAmount } },
+      });
+    } else if (
+      achievement.reward.rewardType === 'item' &&
+      achievement.reward.itemId !== null
+    ) {
+      if (achievement.reward.itemId === 88000001) {
+        await tx.player.update({
+          where: { id: playerId },
+          data: {
+            RingBall: { increment: 10 },
+          },
+        });
+        return true;
+      }
+
+      const lastSeq = await tx.playerItem.findFirst({
+        where: { playerId, itemId: achievement.reward.itemId },
+        orderBy: { seq: 'desc' },
+        select: { seq: true },
+      });
+
+      const seq = lastSeq ? lastSeq.seq + 1 : 0;
+
+      await tx.playerItem.create({
+        data: {
+          playerId,
+          itemId: achievement.reward.itemId,
+          seq,
+          level: 1,
+          description: '',
+        },
+      });
+    }
+
+    return true;
+  });
+};


### PR DESCRIPTION
## Summary
- add Reward, Achievement and PlayerAchievement models
- implement achievement service logic
- add achievement controller and routes
- wire up achievement routes in `app.ts`

## Testing
- `npx tsc --noEmit` *(fails: Cannot find module 'express')*

------
https://chatgpt.com/codex/tasks/task_e_686cdf97811c8332b1f61a3bfeb2aca8