### PR TITLE
Add PlayerAchievements relation to Player model

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -31,7 +31,8 @@ model Player {
   roomUsers   RoomUser[]
   playerItems PlayerItem[]
   histories   History[]
-  effectPlayers EffectPlayer[] 
+  effectPlayers EffectPlayer[]
+  playerAchievements PlayerAchievement[]
 }
 
 


### PR DESCRIPTION
## Summary
- add missing relation array `playerAchievements` to the `Player` model in Prisma schema
- attempted to run `npx prisma format` and `npx prisma generate` but npm access is blocked

## Testing
- `npx prisma format` *(fails: 403 Forbidden)*
- `npx prisma generate` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_686d4569212483328571df419c529348