### PR TITLE
Simplify inventory response

### DIFF
--- a/src/services/itemService.ts
+++ b/src/services/itemService.ts
@@ -21,6 +21,8 @@ export const getInventoryByPlayer = async (playerId: number) => {
 
   if (!player) return null;
 
-  // Trả nguyên thông tin player kèm danh sách playerItems
-  return player;
+  // Trả thông tin player kèm danh sách playerItems đơn giản hóa
+  const simplifiedItems = player.playerItems.map((pi) => ({ seq: pi.seq, item: pi.item }));
+
+  return { ...player, playerItems: simplifiedItems };
 };


### PR DESCRIPTION
## Summary
- refine `getInventoryByPlayer` service to return simpler playerItems

## Testing
- `npm run build` *(fails: cannot download dependencies)*
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_686d494a9b548332adea6d2fe80d0356