### PR TITLE
Fix turnOrder typo in game controller

### DIFF
--- a/src/controllers/gameController.ts
+++ b/src/controllers/gameController.ts
@@ -23,7 +23,7 @@ const generateTransno = (): bigint => {
     for (const entry of req.body) {
       const {
         playerId,
-        tunrOrder,
+        turnOrder,
         typeMatchGid,
         StatusWin,
         rounds,
@@ -47,7 +47,7 @@ const generateTransno = (): bigint => {
       await createHistory({
         playerId,
         transno,
-        turnOrder: tunrOrder,
+        turnOrder,
         typeMatchGid,
         statusWin: StatusWin,
         mapGame: MapGame,


### PR DESCRIPTION
## Summary
- rename `tunrOrder` variable to `turnOrder`
- forward updated property when creating history records

## Testing
- `npm run build` *(fails: cannot find module 'express')*

------
https://chatgpt.com/codex/tasks/task_e_686d4b522c6083329de33a7166ba7113