### PR TITLE
Include player item level in inventory

### DIFF
--- a/src/services/itemService.ts
+++ b/src/services/itemService.ts
@@ -22,10 +22,14 @@ export const getInventoryByPlayer = async (playerId: number) => {
   if (!player) return null;
 
   // Trả thông tin player kèm danh sách playerItems đơn giản hóa
-  const simplifiedItems = player.playerItems.map((pi) => ({
-    seq: pi.seq,
-    ...pi.item,
-  }));
+  const simplifiedItems = player.playerItems.map((pi) => {
+    const { level: _level, ...itemWithoutLevel } = pi.item;
+    return {
+      seq: pi.seq,
+      level: pi.level,
+      ...itemWithoutLevel,
+    };
+  });
 
   return { ...player, playerItems: simplifiedItems };
 };


### PR DESCRIPTION
## Summary
- include `level` from `PlayerItem` when listing inventory items
- exclude the `level` field from the related `Item`

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_686d5701d684833297943c1be25a2482