### PR TITLE
Add history retrieval API

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -9,6 +9,7 @@ import effectPlayerRoutes from './routes/effectPlayerRoutes';
 import playerItemRoutes from './routes/playerItemRoutes';
 import ballPhysicsRoutes from './routes/ballPhysicsRoutes';
 import achievementRoutes from './routes/achievementRoutes';
+import historyRoutes from './routes/historyRoutes';
 
 const app = express();
 
@@ -22,4 +23,5 @@ app.use('/api', effectPlayerRoutes);
 app.use('/api', playerItemRoutes);
 app.use('/api', ballPhysicsRoutes);
 app.use('/api', achievementRoutes);
+app.use('/api', historyRoutes);
 export default app;

--- a/src/controllers/historyController.ts
+++ b/src/controllers/historyController.ts
@@ -1,0 +1,11 @@
+import { Request, Response } from 'express';
+import { getAllHistories } from '../services/historyService';
+
+export const getHistories = async (_req: Request, res: Response) => {
+  try {
+    const histories = await getAllHistories();
+    res.json(histories);
+  } catch (error: any) {
+    res.status(500).json({ message: error.message });
+  }
+};

--- a/src/routes/historyRoutes.ts
+++ b/src/routes/historyRoutes.ts
@@ -1,0 +1,8 @@
+import { Router } from 'express';
+import { getHistories } from '../controllers/historyController';
+
+const router = Router();
+
+router.get('/histories', getHistories);
+
+export default router;

--- a/src/services/historyService.ts
+++ b/src/services/historyService.ts
@@ -39,3 +39,11 @@ export const createHistory = async (data: HistoryData) => {
     },
   });
 };
+
+export const getAllHistories = async () => {
+  return prisma.history.findMany({
+    include: {
+      player: true,
+    },
+  });
+};


### PR DESCRIPTION
## Summary
- implement History controller, route and service function
- hook up new route in app

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68707429c0e48332b31748bbaaeb3e72