### PR TITLE
Implement paginated history endpoint

### DIFF
--- a/ReadMe
+++ b/ReadMe
@@ -22,6 +22,7 @@ GET /api/players/:id/inventory - Túi đồ người chơi
 POST /api/players/ball-physics - Chỉ số vật lý viên bi đang trang bị (danh sách id)
 POST /api/player/equip - Trang bị vật phẩm cho người chơi
 POST /api/effect-player/item-level-up - Nâng cấp level của vật phẩm
+GET /api/histories?page=1&pageSize=10 - Lịch sử trận đấu (mặc định 10 bản ghi gần nhất, hỗ trợ phân trang)
 
 Body JSON /players/ball-physics:
 {

--- a/src/controllers/historyController.ts
+++ b/src/controllers/historyController.ts
@@ -1,9 +1,12 @@
 import { Request, Response } from 'express';
-import { getAllHistories } from '../services/historyService';
+import { getHistories as getHistoriesService } from '../services/historyService';
 
-export const getHistories = async (_req: Request, res: Response) => {
+export const getHistories = async (req: Request, res: Response) => {
   try {
-    const histories = await getAllHistories();
+    const page = parseInt(req.query.page as string) || 1;
+    const pageSize = parseInt(req.query.pageSize as string) || 10;
+    const skip = (page - 1) * pageSize;
+    const histories = await getHistoriesService(skip, pageSize);
     res.json(histories);
   } catch (error: any) {
     res.status(500).json({ message: error.message });

--- a/src/services/historyService.ts
+++ b/src/services/historyService.ts
@@ -40,10 +40,27 @@ export const createHistory = async (data: HistoryData) => {
   });
 };
 
+export const getHistories = async (skip = 0, take = 10) => {
+  return prisma.history.findMany({
+    include: {
+      player: true,
+    },
+    orderBy: {
+      createdAt: 'desc',
+    },
+    skip,
+    take,
+  });
+};
+
+// Keep for backward compatibility if other modules use it
 export const getAllHistories = async () => {
   return prisma.history.findMany({
     include: {
       player: true,
+    },
+    orderBy: {
+      createdAt: 'desc',
     },
   });
 };


### PR DESCRIPTION
## Summary
- fetch histories with pagination defaults
- expose pagination params in controller
- document new /api/histories endpoint

## Testing
- `npm run build` *(fails: Cannot find module 'express')*
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6870790ab12c83329eca210e1e3a7bd9