### PR TITLE
Implement draw reward feature

### DIFF
--- a/ReadMe
+++ b/ReadMe
@@ -23,6 +23,7 @@ POST /api/players/ball-physics - Chỉ số vật lý viên bi đang trang bị 
 POST /api/player/equip - Trang bị vật phẩm cho người chơi
 POST /api/effect-player/item-level-up - Nâng cấp level của vật phẩm
 GET /api/histories?page=1&pageSize=10 - Lịch sử trận đấu (mặc định 10 bản ghi gần nhất, hỗ trợ phân trang)
+POST /api/draw-reward - Bốc thăm trúng thưởng (body: {"playerId": number})
 
 Body JSON /players/ball-physics:
 {

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -174,3 +174,13 @@ model PlayerAchievement {
   @@id([playerId, achievementId])
 }
 
+model DailyRareItem {
+  playerId Int
+  date     DateTime
+  count    Int      @default(0)
+
+  player Player @relation(fields: [playerId], references: [id])
+
+  @@id([playerId, date])
+}
+

--- a/src/app.ts
+++ b/src/app.ts
@@ -10,6 +10,7 @@ import playerItemRoutes from './routes/playerItemRoutes';
 import ballPhysicsRoutes from './routes/ballPhysicsRoutes';
 import achievementRoutes from './routes/achievementRoutes';
 import historyRoutes from './routes/historyRoutes';
+import drawRoutes from './routes/drawRoutes';
 
 const app = express();
 
@@ -24,4 +25,5 @@ app.use('/api', playerItemRoutes);
 app.use('/api', ballPhysicsRoutes);
 app.use('/api', achievementRoutes);
 app.use('/api', historyRoutes);
+app.use('/api', drawRoutes);
 export default app;

--- a/src/controllers/drawController.ts
+++ b/src/controllers/drawController.ts
@@ -1,0 +1,16 @@
+import { Request, Response } from 'express';
+import { drawReward } from '../services/drawService';
+
+export const drawRewardController = async (req: Request, res: Response) => {
+  try {
+    const playerId = Number(req.body.playerId);
+    if (isNaN(playerId)) {
+      res.status(400).json({ message: 'Invalid playerId' });
+      return;
+    }
+    const result = await drawReward(playerId);
+    res.json(result);
+  } catch (error: any) {
+    res.status(500).json({ message: error.message });
+  }
+};

--- a/src/routes/drawRoutes.ts
+++ b/src/routes/drawRoutes.ts
@@ -1,0 +1,8 @@
+import { Router } from 'express';
+import { drawRewardController } from '../controllers/drawController';
+
+const router = Router();
+
+router.post('/draw-reward', drawRewardController);
+
+export default router;

--- a/src/services/drawService.ts
+++ b/src/services/drawService.ts
@@ -1,0 +1,91 @@
+import prisma from '../models/prismaClient';
+import { addItemToInventory } from './playerItemService';
+
+interface RewardResult {
+  type: 'item' | 'culi';
+  itemId?: number;
+  amount?: number;
+}
+
+const getStartOfDay = () => {
+  const d = new Date();
+  d.setUTCHours(0, 0, 0, 0);
+  return d;
+};
+
+export const drawReward = async (playerId: number): Promise<RewardResult> => {
+  const histories = await prisma.history.findMany({
+    where: { playerId, marbBet: { gte: 5 } },
+    orderBy: { createdAt: 'desc' },
+    take: 5,
+  });
+
+  let winStreak = 0;
+  if (histories.length > 0) {
+    const status = histories[0].statusWin;
+    for (const h of histories) {
+      if (h.statusWin === status) {
+        winStreak += 1;
+      } else {
+        break;
+      }
+    }
+  }
+
+  let winBonus = 0;
+  if (winStreak >= 5) winBonus = 30;
+  else if (winStreak >= 4) winBonus = 20;
+  else if (winStreak >= 3) winBonus = 10;
+
+  const lastThree = histories.slice(0, 3);
+  const totalBet = lastThree.reduce((sum, h) => sum + (h.marbBet ?? 0), 0);
+  let betBonus = 0;
+  if (totalBet >= 60) betBonus = 50;
+  else if (totalBet >= 30) betBonus = 25;
+  else betBonus = 10;
+
+  let probability = winBonus + betBonus;
+  if (probability > 100) probability = 100;
+
+  const randomValue = Math.random() * 100;
+  let isRare = randomValue < probability;
+
+  if (isRare) {
+    const day = getStartOfDay();
+    let daily = await prisma.dailyRareItem.findUnique({
+      where: { playerId_date: { playerId, date: day } },
+    });
+    if (!daily) {
+      daily = await prisma.dailyRareItem.create({
+        data: { playerId, date: day, count: 0 },
+      });
+    }
+
+    if (daily.count >= 3) {
+      isRare = false;
+    } else {
+      const items = await prisma.item.findMany({ where: { locationGid: 3 } });
+      if (items.length > 0) {
+        const chosen = items[Math.floor(Math.random() * items.length)];
+        await addItemToInventory(playerId, chosen.id);
+        await prisma.dailyRareItem.update({
+          where: { playerId_date: { playerId, date: day } },
+          data: { count: { increment: 1 } },
+        });
+        return { type: 'item', itemId: chosen.id };
+      } else {
+        isRare = false;
+      }
+    }
+  }
+
+  // Fallback to common reward
+  const amount = Math.random() < 0.5 ? 1 : 0;
+  if (amount > 0) {
+    await prisma.player.update({
+      where: { id: playerId },
+      data: { RingBall: { increment: amount } },
+    });
+  }
+  return { type: 'culi', amount };
+};

--- a/src/services/playerItemService.ts
+++ b/src/services/playerItemService.ts
@@ -187,3 +187,31 @@ export const levelUpPlayerItem = async (
     },
   });
 };
+
+export const addItemToInventory = async (
+  playerId: number,
+  itemId: number
+) => {
+  return prisma.$transaction(async (tx) => {
+    const lastSeq = await tx.playerItem.findFirst({
+      where: {
+        playerId,
+        itemId,
+      },
+      orderBy: { seq: 'desc' },
+      select: { seq: true },
+    });
+
+    const seq = lastSeq ? lastSeq.seq + 1 : 0;
+
+    return tx.playerItem.create({
+      data: {
+        playerId,
+        itemId,
+        seq,
+        level: 1,
+        description: '',
+      },
+    });
+  });
+};


### PR DESCRIPTION
## Summary
- add draw reward endpoint with controller and service
- track rare item draws with DailyRareItem model
- support adding items directly to player inventory
- document new API route

## Testing
- `npm run build` *(fails: Cannot find type definitions)*

------
https://chatgpt.com/codex/tasks/task_e_6870cebdabb08332b41124d896d3b59e