### PR TITLE
Remove player cosmetic fields

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -18,14 +18,9 @@ model Player {
   PlayerName   String?
   Level         Int?
   Exp           Int?
-  Ball          Int?
-  SeqBall       Int?
   Body          Int?
-  Shirt         Int?
-  Pant          Int?
   RingBall      Int?
   Money         Int?
-  Hair          Int?
   TalentPoint   Int?
   IdAccount    String
   roomUsers   RoomUser[]

--- a/src/controllers/playerController.ts
+++ b/src/controllers/playerController.ts
@@ -53,13 +53,13 @@ export const equipItemController: RequestHandler = async (req, res): Promise<voi
     const playerId = Number(req.body.playerId);
     const typeGid = Number(req.body.typeGid);
     const itemId = Number(req.body.itemId);
-    const seqBall = Number(req.body.seqBall);
-    if (isNaN(playerId) || isNaN(typeGid) || isNaN(itemId)) {
+    const seq = Number(req.body.seq);
+    if (isNaN(playerId) || isNaN(typeGid) || isNaN(itemId) || isNaN(seq)) {
       res.status(400).json({ message: 'Invalid playerId, typeGid or itemId' });
       return;
     }
 
-    const updatedPlayer = await equipItem(playerId, typeGid, itemId,seqBall);
+    const updatedPlayer = await equipItem(playerId, typeGid, itemId, seq);
     res.json(updatedPlayer);
     return;
   } catch (error: any) {

--- a/src/services/ballPhysicsService.ts
+++ b/src/services/ballPhysicsService.ts
@@ -11,40 +11,20 @@ export interface BallPhysics {
 }
 
 export const getBallPhysicsByPlayer = async (playerId: number): Promise<BallPhysics | null> => {
-  const player = await prisma.player.findUnique({
-    where: { id: playerId },
-    select: { Ball: true, SeqBall: true },
-  });
-
-  if (!player || player.Ball === null || player.SeqBall === null) {
-    return null;
-  }
-
-  const playerItem = await prisma.playerItem.findUnique({
-    where: { playerId_itemId_seq: { playerId, itemId: player.Ball, seq: player.SeqBall } },
-    select: { level: true },
+  const playerItem = await prisma.playerItem.findFirst({
+    where: {
+      playerId,
+      item: { typeGid: 1 },
+    },
+    include: { item: true },
+    orderBy: { seq: 'asc' },
   });
 
   if (!playerItem) {
     return null;
   }
 
-  const item = await prisma.item.findUnique({
-    where: { id: player.Ball },
-    select: {
-      Mass: true,
-      GravityScale: true,
-      Drag: true,
-      Bounciness: true,
-      Elasticity: true,
-      ImpactResistance: true,
-    },
-  });
-
-  if (!item) {
-    return null;
-  }
-
+  const item = playerItem.item;
   const level = playerItem.level;
   const factor = 1 + 0.1 * (level - 1);
 

--- a/src/services/playerService.ts
+++ b/src/services/playerService.ts
@@ -118,22 +118,17 @@ export const equipItem = async (
   playerId: number,
   typeGid: number,
   itemId: number,
-  seqBall: number
+  seq: number
 ) => {
-  const data: { Ball?: number; Shirt?: number; SeqBall?: number } = {};
-  if (typeGid === 1) {
-    data.Ball = itemId;
-    data.SeqBall = seqBall; // Assuming seqBall is a field in the player model
-  } else if (typeGid === 2) {
-    data.Shirt = itemId;
-  } else {
-    throw new Error('Unsupported typeGid');
+  const playerItem = await prisma.playerItem.findUnique({
+    where: { playerId_itemId_seq: { playerId, itemId, seq } },
+  });
+
+  if (!playerItem) {
+    throw new Error('Item not found in inventory');
   }
 
-  return prisma.player.update({
-    where: { id: playerId },
-    data,
-  });
+  return playerItem;
 };
 
 


### PR DESCRIPTION
## Summary
- drop Ball/SeqBall/Shirt/Pant/Hair columns from the Player model
- adjust services and controller to stop using removed fields
- update ball physics service to derive data from PlayerItem records

## Testing
- `npx prisma generate` *(fails: 403 Forbidden - registry.npmjs.org)*
- `npx prisma db push` *(fails: 403 Forbidden - registry.npmjs.org)*
- `npm run build` *(fails: cannot find module 'express')*

------
https://chatgpt.com/codex/tasks/task_e_6878f0dd7b048332be2a02792a0e3273