### PR TITLE
Update inventory endpoints

### DIFF
--- a/src/services/itemService.ts
+++ b/src/services/itemService.ts
@@ -32,5 +32,49 @@ export const getInventoryByPlayer = async (playerId: number) => {
     };
   });
 
-  return { ...player, playerItems: simplifiedItems };
+  // Lấy thông tin các vật phẩm đang trang bị
+  const equipIds: { key: string; id: number | null; seq?: number | null }[] = [
+    { key: 'Ball', id: player.Ball, seq: player.SeqBall },
+    { key: 'Body', id: player.Body },
+    { key: 'Shirt', id: player.Shirt },
+    { key: 'Pant', id: player.Pant },
+    { key: 'Hair', id: player.Hair },
+  ];
+
+  const equippedItems: Record<string, any> = {};
+  for (const equip of equipIds) {
+    if (equip.id === null || equip.id === undefined) continue;
+    const pi = await prisma.playerItem.findUnique({
+      where: {
+        playerId_itemId_seq: {
+          playerId,
+          itemId: equip.id,
+          seq: equip.seq ?? 0,
+        },
+      },
+      include: { item: true },
+    });
+
+    if (pi) {
+      const { level: _lvl, ...itemWithoutLevel } = pi.item;
+      equippedItems[equip.key] = {
+        seq: pi.seq,
+        level: pi.level,
+        ...itemWithoutLevel,
+      };
+    } else {
+      const item = await prisma.item.findUnique({ where: { id: equip.id } });
+      if (item) {
+        const { level: _lvl, ...itemWithoutLevel } = item;
+        equippedItems[equip.key] = {
+          seq: equip.seq ?? 0,
+          level: 1,
+          ...itemWithoutLevel,
+        };
+      }
+    }
+  }
+
+  const { playerItems, ...rest } = player;
+  return { ...rest, playerItems: simplifiedItems, equippedItems };
 };

--- a/src/services/playerService.ts
+++ b/src/services/playerService.ts
@@ -23,6 +23,8 @@ export const getPlayerByListId = async (ids: number[]) => {
           level: true,
         },
       },
+      // Include equipPlayers relation so caller can know equipped items
+      equipPlayers: true,
     },
   });
 


### PR DESCRIPTION
## Summary
- include `equipPlayers` when fetching players
- extend inventory service to return equipped items

## Testing
- `npm run build` *(fails: Cannot find module 'express' or its corresponding type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_6878f0df4df0833291de1fd041acaffc