### PR TITLE
Use EquipPlayer for ball physics

### DIFF
--- a/src/services/ballPhysicsService.ts
+++ b/src/services/ballPhysicsService.ts
@@ -1,5 +1,8 @@
 import prisma from '../models/prismaClient';
 
+// Location id used in EquipPlayer to mark the equipped ball slot
+const BALL_SLOT_LOCATION_ID = 2;
+
 export interface BallPhysics {
   Mass: number | null;
   GravityScale: number | null;
@@ -10,18 +13,27 @@ export interface BallPhysics {
   level: number;
 }
 
-export const getBallPhysicsByPlayer = async (playerId: number): Promise<BallPhysics | null> => {
-  const player = await prisma.player.findUnique({
-    where: { id: playerId },
-    select: { Ball: true, SeqBall: true },
+export const getBallPhysicsByPlayer = async (
+  playerId: number
+): Promise<BallPhysics | null> => {
+  // Get equipped ball from EquipPlayer table based on location
+  const equip = await (prisma as any).equipPlayer.findFirst({
+    where: { playerId, locationId: BALL_SLOT_LOCATION_ID },
+    select: { itemId: true, seq: true },
   });
 
-  if (!player || player.Ball === null || player.SeqBall === null) {
+  if (!equip) {
     return null;
   }
 
   const playerItem = await prisma.playerItem.findUnique({
-    where: { playerId_itemId_seq: { playerId, itemId: player.Ball, seq: player.SeqBall } },
+    where: {
+      playerId_itemId_seq: {
+        playerId,
+        itemId: equip.itemId,
+        seq: equip.seq,
+      },
+    },
     select: { level: true },
   });
 
@@ -30,7 +42,7 @@ export const getBallPhysicsByPlayer = async (playerId: number): Promise<BallPhys
   }
 
   const item = await prisma.item.findUnique({
-    where: { id: player.Ball },
+    where: { id: equip.itemId },
     select: {
       Mass: true,
       GravityScale: true,

--- a/src/services/playerService.ts
+++ b/src/services/playerService.ts
@@ -1,6 +1,9 @@
 // src/services/playerService.ts
 import prisma from '../models/prismaClient'; // Import Prisma Client
 
+// Location id used in EquipPlayer to mark the equipped ball slot
+const BALL_SLOT_LOCATION_ID = 2;
+
 export const getPlayerByAccountId = async (accountId: string) => {
   return await prisma.player.findFirst({
     where: { IdAccount: accountId },
@@ -123,7 +126,25 @@ export const equipItem = async (
   const data: { Ball?: number; Shirt?: number; SeqBall?: number } = {};
   if (typeGid === 1) {
     data.Ball = itemId;
-    data.SeqBall = seqBall; // Assuming seqBall is a field in the player model
+    data.SeqBall = seqBall;
+
+    // Update EquipPlayer table for the ball slot
+    const locationId = BALL_SLOT_LOCATION_ID;
+    const existing = await (prisma as any).equipPlayer.findFirst({
+      where: { playerId, locationId },
+      select: { playerId: true },
+    });
+
+    if (existing) {
+      await (prisma as any).equipPlayer.update({
+        where: { playerId_locationId: { playerId, locationId } },
+        data: { itemId, seq: seqBall },
+      });
+    } else {
+      await (prisma as any).equipPlayer.create({
+        data: { playerId, locationId, itemId, seq: seqBall },
+      });
+    }
   } else if (typeGid === 2) {
     data.Shirt = itemId;
   } else {


### PR DESCRIPTION
## Summary
- retrieve equipped ball via `EquipPlayer` table when calculating ball physics
- keep track of equipped ball in `equipItem`

## Testing
- `npm run build` *(fails: Cannot find module 'express')*
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6878f0e059a4833297aa00d5115292cb