### PR TITLE
Refactor inventory retrieval

### DIFF
--- a/src/services/itemService.ts
+++ b/src/services/itemService.ts
@@ -1,18 +1,8 @@
 import prisma from '../models/prismaClient';
 
-// Map locationId in EquipPlayer to human readable keys
-const LOCATION_KEY_MAP: Record<number, string> = {
-  1: 'Culi1',
-  2: 'Culi2',
-  3: 'Culi3',
-  4: 'Shirt',
-  5: 'Pant',
-  6: 'Hair',
-};
-
- export const getAllItems = async () => {
+export const getAllItems = async () => {
   return prisma.item.findMany({
-    where: { locationGid: 2,isOpen: true },
+    where: { locationGid: 2, isOpen: true },
     orderBy: { id: 'asc' },
   });
 };
@@ -44,13 +34,10 @@ export const getInventoryByPlayer = async (playerId: number) => {
   });
 
   // Thông tin các vật phẩm đang trang bị
-  const equippedItems: Record<string, any> = {};
+  const equippedItems: any[] = [];
 
-  // Lấy trang phục culi, áo quần, tóc từ bảng EquipPlayer
+  // Lấy thông tin trang bị từ bảng EquipPlayer
   for (const equip of player.equipPlayers) {
-    const key = LOCATION_KEY_MAP[equip.locationId];
-    if (!key) continue;
-
     const pi = player.playerItems.find(
       (i) => i.itemId === equip.itemId && i.seq === equip.seqItem
     );
@@ -58,35 +45,36 @@ export const getInventoryByPlayer = async (playerId: number) => {
     const level = pi?.level ?? 1;
     const { level: _lvl, ...itemWithoutLevel } = equip.item as any;
 
-    equippedItems[key] = {
+    equippedItems.push({
+      locationId: equip.locationId,
       seq: equip.seqItem,
       level,
       ...itemWithoutLevel,
-    };
+    });
   }
 
   // Body vẫn được lưu ở bảng Player
   if (player.Body !== null && player.Body !== undefined) {
-    const pi = player.playerItems.find(
-      (i) => i.itemId === player.Body
-    );
+    const pi = player.playerItems.find((i) => i.itemId === player.Body);
 
     if (pi) {
       const { level: _lvl, ...itemWithoutLevel } = pi.item;
-      equippedItems['Body'] = {
+      equippedItems.push({
+        locationId: 0,
         seq: pi.seq,
         level: pi.level,
         ...itemWithoutLevel,
-      };
+      });
     } else {
       const item = await prisma.item.findUnique({ where: { id: player.Body } });
       if (item) {
         const { level: _lvl, ...itemWithoutLevel } = item;
-        equippedItems['Body'] = {
+        equippedItems.push({
+          locationId: 0,
           seq: 0,
           level: 1,
           ...itemWithoutLevel,
-        };
+        });
       }
     }
   }


### PR DESCRIPTION
## Summary
- refactor `getInventoryByPlayer` to remove LOCATION_KEY_MAP
- return equipped items as an array for easier reuse

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run build` *(fails to install dependencies)*


------
https://chatgpt.com/codex/tasks/task_e_68791c735f3c8332b09b8037276c2fc6