### PR TITLE
Fix inventory filtering for equipped items

### DIFF
--- a/src/services/itemService.ts
+++ b/src/services/itemService.ts
@@ -79,6 +79,14 @@ export const getInventoryByPlayer = async (playerId: number) => {
     }
   }
 
+  const equippedIdSeq = new Set(
+    equippedItems.map((ei: any) => `${ei.id}-${ei.seq}`)
+  );
+
+  const filteredItems = simplifiedItems.filter(
+    (it) => !equippedIdSeq.has(`${it.id}-${it.seq}`)
+  );
+
   const { playerItems, equipPlayers, ...rest } = player;
-  return { ...rest, playerItems: simplifiedItems, equippedItems };
+  return { ...rest, playerItems: filteredItems, equippedItems };
 };


### PR DESCRIPTION
## Summary
- ensure `/players/:id/inventory` doesn't return items already equipped

## Testing
- `npm run build` *(fails: Cannot find module 'express')*

------
https://chatgpt.com/codex/tasks/task_e_6879b605faf48332a9bf7016fc5fc975