### PR TITLE
Modify Prisma schema for item trading

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -77,12 +77,14 @@ model Item {
    equipPlayers EquipPlayer[] 
 }
 
-model PlayerItem { 
+model PlayerItem {
   playerId Int
   itemId   Int
-  seq      Int 
-  level    Int   
+  seq      Int
+  level    Int
   description String
+  Price     Int?   @default(0)
+  IsSolded  Int    @default(0) // 0: none, 1: listed, 2: sold
 
   player Player @relation(fields: [playerId], references: [id])
   item   Item   @relation(fields: [itemId], references: [id])
@@ -194,5 +196,15 @@ model EquipPlayer {
   item   Item   @relation(fields: [itemId], references: [id])
 
   @@id([playerId, locationId])
+}
+
+model ItemTradeHistory {
+  playerIdBuy  Int
+  playerIdSold Int
+  itemId       Int
+  seq          Int
+  createdAt    DateTime @default(now())
+
+  @@id([playerIdBuy, playerIdSold, itemId, seq])
 }
 


### PR DESCRIPTION
## Summary
- expand `PlayerItem` with `Price` and `IsSolded`
- add new model `ItemTradeHistory`
- try to run `prisma generate` and `prisma db push`

## Testing
- `npx prisma generate` *(fails: 403 Forbidden)*
- `npx prisma db push` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_687dd921b678833294d7d9631a54bd9a