### PR TITLE
Add market routes and controller

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -11,6 +11,7 @@ import ballPhysicsRoutes from './routes/ballPhysicsRoutes';
 import achievementRoutes from './routes/achievementRoutes';
 import historyRoutes from './routes/historyRoutes';
 import drawRoutes from './routes/drawRoutes';
+import marketRoutes from './routes/marketRoutes';
 
 const app = express();
 
@@ -26,4 +27,5 @@ app.use('/api', ballPhysicsRoutes);
 app.use('/api', achievementRoutes);
 app.use('/api', historyRoutes);
 app.use('/api', drawRoutes);
+app.use('/api', marketRoutes);
 export default app;

--- a/src/controllers/marketController.ts
+++ b/src/controllers/marketController.ts
@@ -1,0 +1,73 @@
+import { Request, Response } from 'express';
+import {
+  listItemForSale,
+  buyMarketItem,
+  cancelSale,
+  getAllListedItems
+} from '../services/marketService';
+
+export const sellOnMarket = async (req: Request, res: Response) => {
+  try {
+    const playerId = Number(req.body.playerId);
+    const itemId = Number(req.body.itemId);
+    const seq = Number(req.body.seq);
+    const price = Number(req.body.price);
+
+    if ([playerId, itemId, seq, price].some((v) => isNaN(v))) {
+      res.status(400).json({ message: 'Invalid parameters' });
+      return;
+    }
+
+    const result = await listItemForSale(playerId, itemId, seq, price);
+    res.json(result);
+  } catch (error: any) {
+    res.status(500).json({ message: error.message });
+  }
+};
+
+export const buyOnMarket = async (req: Request, res: Response) => {
+  try {
+    const buyerId = Number(req.body.buyerId);
+    const sellerId = Number(req.body.sellerId);
+    const itemId = Number(req.body.itemId);
+    const seq = Number(req.body.seq);
+
+    if ([buyerId, sellerId, itemId, seq].some((v) => isNaN(v))) {
+      res.status(400).json({ message: 'Invalid parameters' });
+      return;
+    }
+
+    const result = await buyMarketItem(buyerId, sellerId, itemId, seq);
+    res.json(result);
+  } catch (error: any) {
+    res.status(500).json({ message: error.message });
+  }
+};
+
+export const cancelSell = async (req: Request, res: Response) => {
+  try {
+    const playerId = Number(req.body.playerId);
+    const itemId = Number(req.body.itemId);
+    const seq = Number(req.body.seq);
+
+    if ([playerId, itemId, seq].some((v) => isNaN(v))) {
+      res.status(400).json({ message: 'Invalid parameters' });
+      return;
+    }
+
+    const result = await cancelSale(playerId, itemId, seq);
+    res.json(result);
+  } catch (error: any) {
+    res.status(500).json({ message: error.message });
+  }
+};
+
+export const getListedItems = async (_req: Request, res: Response) => {
+  try {
+    const items = await getAllListedItems();
+    res.json(items);
+  } catch (error: any) {
+    res.status(500).json({ message: error.message });
+  }
+};
+

--- a/src/routes/marketRoutes.ts
+++ b/src/routes/marketRoutes.ts
@@ -1,0 +1,9 @@
+import { Router } from 'express';
+import * as marketController from '../controllers/marketController';
+
+const router = Router();
+router.post('/market/sell', marketController.sellOnMarket);
+router.post('/market/buy', marketController.buyOnMarket);
+router.post('/market/cancel', marketController.cancelSell);
+router.get('/market/items', marketController.getListedItems);
+export default router;


### PR DESCRIPTION
## Summary
- implement `marketController` with functions for listing, buying, canceling, and getting items
- expose REST endpoints in `marketRoutes`
- register new routes in the Express app

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_687ddc32984883329f8a213de49da23b