### PR TITLE
Add market item filtering

### DIFF
--- a/ReadMe
+++ b/ReadMe
@@ -24,6 +24,7 @@ POST /api/player/equip - Trang bị vật phẩm cho người chơi
 POST /api/effect-player/item-level-up - Nâng cấp level của vật phẩm
 GET /api/histories?page=1&pageSize=10 - Lịch sử trận đấu (mặc định 10 bản ghi gần nhất, hỗ trợ phân trang)
 POST /api/draw-reward - Bốc thăm trúng thưởng (body: {"playerId": number})
+GET /api/market/items?page=1&itemName=X&level=1&priceOrder=asc&levelOrder=desc - Danh sách vật phẩm bán trên chợ, hỗ trợ lọc và phân trang (mặc định 10 bản ghi mỗi trang)
 
 Body JSON /players/ball-physics:
 {

--- a/src/controllers/marketController.ts
+++ b/src/controllers/marketController.ts
@@ -3,7 +3,7 @@ import {
   listItemForSale,
   buyMarketItem,
   cancelSale,
-  getAllListedItems
+  getListedItems as getListedItemsService
 } from '../services/marketService';
 
 export const sellOnMarket = async (req: Request, res: Response) => {
@@ -62,9 +62,25 @@ export const cancelSell = async (req: Request, res: Response) => {
   }
 };
 
-export const getListedItems = async (_req: Request, res: Response) => {
+export const getListedItems = async (req: Request, res: Response) => {
   try {
-    const items = await getAllListedItems();
+    const itemName = req.query.itemName as string | undefined;
+    const level = req.query.level ? Number(req.query.level) : undefined;
+    const priceOrder = req.query.priceOrder as 'asc' | 'desc' | undefined;
+    const levelOrder = req.query.levelOrder as 'asc' | 'desc' | undefined;
+
+    const page = parseInt(req.query.page as string) || 1;
+    const pageSize = 10;
+    const skip = (page - 1) * pageSize;
+
+    const items = await getListedItemsService({
+      itemName,
+      level,
+      priceOrder,
+      levelOrder,
+      skip,
+      take: pageSize
+    });
     res.json(items);
   } catch (error: any) {
     res.status(500).json({ message: error.message });

--- a/src/services/marketService.ts
+++ b/src/services/marketService.ts
@@ -131,3 +131,47 @@ export const getAllListedItems = async () => {
     include: { item: true }
   });
 };
+
+export interface ListedItemFilters {
+  itemName?: string;
+  level?: number;
+  priceOrder?: 'asc' | 'desc';
+  levelOrder?: 'asc' | 'desc';
+  skip?: number;
+  take?: number;
+}
+
+export const getListedItems = async ({
+  itemName,
+  level,
+  priceOrder,
+  levelOrder,
+  skip = 0,
+  take = 10
+}: ListedItemFilters) => {
+  const where: any = { IsSolded: 1 };
+
+  if (level !== undefined && !isNaN(level)) {
+    where.level = level;
+  }
+
+  if (itemName) {
+    where.item = { name: { contains: itemName, mode: 'insensitive' } };
+  }
+
+  const orderBy: any[] = [];
+  if (priceOrder) {
+    orderBy.push({ Price: priceOrder });
+  }
+  if (levelOrder) {
+    orderBy.push({ level: levelOrder });
+  }
+
+  return prisma.playerItem.findMany({
+    where,
+    include: { item: true },
+    orderBy: orderBy.length > 0 ? orderBy : undefined,
+    skip,
+    take
+  });
+};


### PR DESCRIPTION
## Summary
- support filtering market listings by name, level and order
- paginate market item results
- document market item filter parameters

## Testing
- `npm run build` *(fails: Cannot find module 'express' or its corresponding type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_687df2e3ac748332b0c937798b81776c