### PR TITLE
Implement account creation API

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -12,6 +12,7 @@ import achievementRoutes from './routes/achievementRoutes';
 import historyRoutes from './routes/historyRoutes';
 import drawRoutes from './routes/drawRoutes';
 import marketRoutes from './routes/marketRoutes';
+import accountRoutes from './routes/accountRoutes';
 
 const app = express();
 
@@ -28,4 +29,5 @@ app.use('/api', achievementRoutes);
 app.use('/api', historyRoutes);
 app.use('/api', drawRoutes);
 app.use('/api', marketRoutes);
+app.use('/api', accountRoutes);
 export default app;

--- a/src/controllers/accountController.ts
+++ b/src/controllers/accountController.ts
@@ -1,0 +1,18 @@
+import { Request, Response } from 'express';
+import { createAccount } from '../services/playerService';
+
+export const createAccountController = async (req: Request, res: Response) => {
+  try {
+    const { idToken, playerName } = req.body;
+
+    if (typeof idToken !== 'string' || typeof playerName !== 'string') {
+      res.status(400).json({ message: 'Invalid idToken or playerName' });
+      return;
+    }
+
+    const player = await createAccount(idToken, playerName);
+    res.json(player);
+  } catch (error: any) {
+    res.status(500).json({ message: error.message });
+  }
+};

--- a/src/routes/accountRoutes.ts
+++ b/src/routes/accountRoutes.ts
@@ -1,0 +1,8 @@
+import { Router } from 'express';
+import { createAccountController } from '../controllers/accountController';
+
+const router = Router();
+
+router.post('/create-account', createAccountController);
+
+export default router;

--- a/src/services/playerService.ts
+++ b/src/services/playerService.ts
@@ -187,4 +187,47 @@ export const equipPlayerItem = async (
   });
 };
 
+export const createAccount = async (idToken: string, playerName: string) => {
+  return prisma.$transaction(async (tx) => {
+    const player = await tx.player.create({
+      data: {
+        IdAccount: idToken,
+        PlayerName: playerName,
+        Level: 1,
+        Exp: 0,
+        Body: 0,
+        RingBall: 0,
+        Money: 0,
+        TalentPoint: 0,
+      },
+    });
+
+    const effectIds = [
+      11000001,
+      11000002,
+      11000003,
+      11000004,
+      11000005,
+      11000006,
+      11000007,
+      11000008,
+    ];
+
+    await tx.effectPlayer.createMany({
+      data: effectIds.map((effectId) => ({
+        playerId: player.id,
+        effectId,
+        power: 0,
+        spin: 0,
+        level: 0,
+        isPassive: false,
+        charges: 0,
+        description: '',
+      })),
+    });
+
+    return player;
+  });
+};
+
 


### PR DESCRIPTION
## Summary
- add POST `/create-account` route
- create account controller
- support player creation with default effect records

## Testing
- `npm install` *(fails: network disabled)*

------
https://chatgpt.com/codex/tasks/task_e_6880948abe64833288155d14883233d4