### PR TITLE
Implement account existence check endpoint

### DIFF
--- a/src/controllers/accountController.ts
+++ b/src/controllers/accountController.ts
@@ -1,5 +1,5 @@
 import { Request, Response } from 'express';
-import { createAccount } from '../services/playerService';
+import { createAccount, getPlayerByAccountId } from '../services/playerService';
 
 export const createAccountController = async (req: Request, res: Response) => {
   try {
@@ -12,6 +12,27 @@ export const createAccountController = async (req: Request, res: Response) => {
 
     const player = await createAccount(idToken, playerName);
     res.json(player);
+  } catch (error: any) {
+    res.status(500).json({ message: error.message });
+  }
+};
+
+export const checkAccountController = async (req: Request, res: Response) => {
+  try {
+    const { idToken } = req.body;
+
+    if (typeof idToken !== 'string') {
+      res.status(400).json({ message: 'Invalid idToken' });
+      return;
+    }
+
+    const player = await getPlayerByAccountId(idToken);
+
+    if (player) {
+      res.json(player);
+    } else {
+      res.json({ player: null, message: 'Chưa có tài khoản' });
+    }
   } catch (error: any) {
     res.status(500).json({ message: error.message });
   }

--- a/src/routes/accountRoutes.ts
+++ b/src/routes/accountRoutes.ts
@@ -1,8 +1,9 @@
 import { Router } from 'express';
-import { createAccountController } from '../controllers/accountController';
+import { createAccountController, checkAccountController } from '../controllers/accountController';
 
 const router = Router();
 
 router.post('/create-account', createAccountController);
+router.post('/check-account', checkAccountController);
 
 export default router;


### PR DESCRIPTION
## Summary
- add controller to check if an account already exists
- expose `/check-account` endpoint in account routes

## Testing
- `npm run build` *(fails: Cannot find module 'express' or its corresponding type declarations)*
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_688099c512808332a5828305b68177a1