### PR TITLE
Add default item on account create

### DIFF
--- a/src/services/playerService.ts
+++ b/src/services/playerService.ts
@@ -189,6 +189,14 @@ export const equipPlayerItem = async (
 
 export const createAccount = async (idToken: string, playerName: string) => {
   return prisma.$transaction(async (tx) => {
+    const existing = await tx.player.findFirst({
+      where: { IdAccount: idToken },
+    });
+
+    if (existing) {
+      return existing;
+    }
+
     const player = await tx.player.create({
       data: {
         IdAccount: idToken,
@@ -199,6 +207,28 @@ export const createAccount = async (idToken: string, playerName: string) => {
         RingBall: 0,
         Money: 0,
         TalentPoint: 0,
+      },
+    });
+
+    await tx.playerItem.create({
+      data: {
+        playerId: player.id,
+        itemId: 99000001,
+        seq: 0,
+        level: 1,
+        description: '',
+        Price: 0,
+        IsSolded: 3,
+      },
+    });
+
+    await tx.equipPlayer.create({
+      data: {
+        playerId: player.id,
+        locationId: 1,
+        itemId: 99000001,
+        seqItem: 0,
+        createdDate: new Date(),
       },
     });
 


### PR DESCRIPTION
## Summary
- avoid duplicate player creation by checking existing IdAccount
- insert default player item and equip data when creating an account

## Testing
- `npm run build` *(fails: cannot find module 'express' and other dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68819370e3948332bcc2165ea2a3174b