### PR TITLE
Ensure only active players are processed

### DIFF
--- a/src/services/achievementService.ts
+++ b/src/services/achievementService.ts
@@ -35,6 +35,14 @@ export const claimAchievementReward = async (
   achievementId: number,
 ) => {
   return prisma.$transaction(async (tx) => {
+    const active = await tx.player.findFirst({
+      where: { id: playerId, IsActive: true },
+      select: { id: true },
+    });
+
+    if (!active) {
+      throw new Error('Player not found or inactive');
+    }
     const achievement = await tx.achievement.findUnique({
       where: { id: achievementId },
       include: { reward: true },

--- a/src/services/drawService.ts
+++ b/src/services/drawService.ts
@@ -14,6 +14,14 @@ const getStartOfDay = () => {
 };
 
 export const drawReward = async (playerId: number): Promise<RewardResult> => {
+  const active = await prisma.player.findFirst({
+    where: { id: playerId, IsActive: true },
+    select: { id: true },
+  });
+
+  if (!active) {
+    throw new Error('Player not found or inactive');
+  }
   const histories = await prisma.history.findMany({
     where: { playerId, marbBet: { gte: 5 } },
     orderBy: { createdAt: 'desc' },

--- a/src/services/effectPlayerService.ts
+++ b/src/services/effectPlayerService.ts
@@ -2,7 +2,7 @@ import prisma from '../models/prismaClient';
 
 export const getByPlayerId = async (playerId: number) => {
   return prisma.effectPlayer.findMany({
-    where: { playerId },
+    where: { playerId, player: { IsActive: true } },
     include: {
       sysMasGeneral: {
         select: {
@@ -26,13 +26,13 @@ export const levelUpEffectPlayer = async (
   effectId: number
 ) => {
   return prisma.$transaction(async (tx) => {
-    const player = await tx.player.findUnique({
-      where: { id: playerId },
+    const player = await tx.player.findFirst({
+      where: { id: playerId, IsActive: true },
       select: { TalentPoint: true },
     });
 
     if (!player) {
-      throw new Error('Player not found');
+      throw new Error('Player not found or inactive');
     }
 
     const currentTP = player.TalentPoint ?? 0;

--- a/src/services/itemService.ts
+++ b/src/services/itemService.ts
@@ -9,8 +9,8 @@ export const getAllItems = async () => {
 
 export const getInventoryByPlayer = async (playerId: number) => {
   // Lấy thông tin player
-  const player = await prisma.player.findUnique({
-    where: { id: playerId },
+  const player = await prisma.player.findFirst({
+    where: { id: playerId, IsActive: true },
     include: {
       playerItems: {
         include: { item: true },

--- a/src/services/marketService.ts
+++ b/src/services/marketService.ts
@@ -41,18 +41,27 @@ export const buyMarketItem = async (
       throw new Error('Item not available');
     }
 
-    const buyer = await tx.player.findUnique({
-      where: { id: buyerId },
+    const buyer = await tx.player.findFirst({
+      where: { id: buyerId, IsActive: true },
       select: { RingBall: true }
     });
 
     if (!buyer) {
-      throw new Error('Buyer not found');
+      throw new Error('Buyer not found or inactive');
     }
 
     const price = item.Price ?? 0;
     if ((buyer.RingBall ?? 0) < price) {
       throw new Error('Not enough RingBall');
+    }
+
+    const seller = await tx.player.findFirst({
+      where: { id: sellerId, IsActive: true },
+      select: { id: true }
+    });
+
+    if (!seller) {
+      throw new Error('Seller not found or inactive');
     }
 
     await tx.player.update({

--- a/src/services/playerItemService.ts
+++ b/src/services/playerItemService.ts
@@ -11,13 +11,13 @@ export const buyItem = async (playerId: number, itemId: number) => {
       throw new Error('Item not found');
     }
 
-    const player = await tx.player.findUnique({
-      where: { id: playerId },
+    const player = await tx.player.findFirst({
+      where: { id: playerId, IsActive: true },
       select: { Money: true, RingBall: true }
     });
 
     if (!player) {
-      throw new Error('Player not found');
+      throw new Error('Player not found or inactive');
     }
 
     const costMoney = item.price ?? 0;
@@ -97,6 +97,15 @@ export const sellItem = async (
 
     if (!item) {
       throw new Error('Item not found');
+    }
+
+    const active = await tx.player.findFirst({
+      where: { id: playerId, IsActive: true },
+      select: { id: true },
+    });
+
+    if (!active) {
+      throw new Error('Player not found or inactive');
     }
 
     if (itemId === 88000001) {

--- a/src/services/playerService.ts
+++ b/src/services/playerService.ts
@@ -6,7 +6,7 @@ const BALL_SLOT_LOCATION_ID = 2;
 
 export const getPlayerByAccountId = async (accountId: string) => {
   return await prisma.player.findFirst({
-    where: { IdAccount: accountId },
+    where: { IdAccount: accountId, IsActive: true },
   });
 };
 
@@ -17,6 +17,7 @@ export const getPlayerByListId = async (ids: number[]) => {
       id: {
         in: ids,
       },
+      IsActive: true,
     },
     include: {
       effectPlayers: {
@@ -52,8 +53,8 @@ export const updatePlayerStats = async (
   expGain: number,
   ballDelta: number
 ) => {
-  const player = await prisma.player.findUnique({
-    where: { id: playerId },
+  const player = await prisma.player.findFirst({
+    where: { id: playerId, IsActive: true },
     select: { Exp: true, Level: true, TalentPoint: true },
   });
 
@@ -125,6 +126,14 @@ export const equipItem = async (
   itemId: number,
   seq: number
 ) => {
+  const active = await prisma.player.findFirst({
+    where: { id: playerId, IsActive: true },
+    select: { id: true },
+  });
+
+  if (!active) {
+    throw new Error('Player not found or inactive');
+  }
   const data: { Ball?: number; Shirt?: number; SeqBall?: number } = {};
 
   if (typeGid === 1) {
@@ -190,7 +199,7 @@ export const equipPlayerItem = async (
 export const createAccount = async (idToken: string, playerName: string) => {
   return prisma.$transaction(async (tx) => {
     const existing = await tx.player.findFirst({
-      where: { IdAccount: idToken },
+      where: { IdAccount: idToken, IsActive: true },
     });
 
     if (existing) {


### PR DESCRIPTION
## Summary
- enforce `IsActive: true` across player queries and updates
- validate active players before modifying stats, items, effects, draws, or rewards

## Testing
- `npx tsc --noEmit` *(fails: Cannot find type definition file for 'express', 'node', etc.)*
- `npm run build` *(fails: Cannot find type definition file for 'express', 'node', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68872b7961f48332a9f417fff4a0da18