### PR TITLE
feat: allow friends to transfer items

### DIFF
--- a/src/controllers/friendController.ts
+++ b/src/controllers/friendController.ts
@@ -4,6 +4,7 @@ import {
   removeFriend,
   respondFriendRequest,
   sendMessage,
+  receiveItems,
 } from '../services/friendService';
 
 export const sendFriendRequestController = async (
@@ -116,6 +117,47 @@ export const sendMessageController = async (
     );
     if (result.success) {
       res.json(result.data);
+      return;
+    }
+    res.status(400).json({ message: result.message });
+  } catch (error: any) {
+    res.status(500).json({ message: error.message });
+  }
+};
+
+export const receiveItemsController = async (
+  req: Request,
+  res: Response
+): Promise<void> => {
+  try {
+    const senderId = Number(req.body.senderId ?? req.params.senderId);
+    const receiverId = Number(req.body.receiverId ?? req.params.receiverId);
+    const items = req.body.items;
+
+    if (
+      isNaN(senderId) ||
+      isNaN(receiverId) ||
+      !Array.isArray(items) ||
+      !items.every(
+        (it: any) =>
+          it &&
+          typeof it === 'object' &&
+          !isNaN(Number(it.itemId)) &&
+          !isNaN(Number(it.seq))
+      )
+    ) {
+      res.status(400).json({ message: 'Invalid parameters' });
+      return;
+    }
+
+    const parsedItems = items.map((it: any) => ({
+      itemId: Number(it.itemId),
+      seq: Number(it.seq),
+    }));
+
+    const result = await receiveItems(senderId, receiverId, parsedItems);
+    if (result.success) {
+      res.json(result);
       return;
     }
     res.status(400).json({ message: result.message });

--- a/src/routes/friendRoutes.ts
+++ b/src/routes/friendRoutes.ts
@@ -5,6 +5,7 @@ import {
   removeFriendController,
   respondFriendRequestController,
   sendMessageController,
+  receiveItemsController,
 } from '../controllers/friendController';
 
 const router = Router();
@@ -13,5 +14,6 @@ router.post('/friend-request', sendFriendRequestController);
 router.post('/friend-remove', removeFriendController);
 router.post('/friend-respond', respondFriendRequestController);
 router.post('/send-message', sendMessageController);
+router.post('/receive-items', receiveItemsController);
 
 export default router;

--- a/src/services/friendService.ts
+++ b/src/services/friendService.ts
@@ -90,3 +90,66 @@ export const sendMessage = async (
   }
 };
 
+export const receiveItems = async (
+  senderId: number,
+  receiverId: number,
+  items: Array<{ itemId: number; seq: number }>
+) => {
+  try {
+    await prisma.$transaction(async (tx) => {
+      for (const { itemId, seq } of items) {
+        if (itemId === 0) {
+          const quantity = seq;
+          const sender = await tx.player.findUnique({
+            where: { id: senderId },
+            select: { RingBall: true },
+          });
+          if (!sender || (sender.RingBall ?? 0) < quantity) {
+            throw new Error('Not enough RingBall');
+          }
+          await tx.player.update({
+            where: { id: senderId },
+            data: { RingBall: { decrement: quantity } },
+          });
+          await tx.player.update({
+            where: { id: receiverId },
+            data: { RingBall: { increment: quantity } },
+          });
+        } else {
+          const playerItem = await tx.playerItem.findUnique({
+            where: {
+              playerId_itemId_seq: { playerId: senderId, itemId, seq },
+            },
+          });
+          if (!playerItem) {
+            throw new Error('Sender does not own item');
+          }
+          await tx.playerItem.delete({
+            where: {
+              playerId_itemId_seq: { playerId: senderId, itemId, seq },
+            },
+          });
+          const lastSeq = await tx.playerItem.findFirst({
+            where: { playerId: receiverId, itemId },
+            orderBy: { seq: 'desc' },
+            select: { seq: true },
+          });
+          const newSeq = lastSeq ? lastSeq.seq + 1 : 0;
+          await tx.playerItem.create({
+            data: {
+              playerId: receiverId,
+              itemId,
+              seq: newSeq,
+              level: playerItem.level,
+              description: `item được gửi từ user: ${senderId}`,
+            },
+          });
+        }
+      }
+    });
+    return { success: true };
+  } catch (error: any) {
+    return { success: false, message: error.message };
+  }
+};
+


### PR DESCRIPTION
## Summary
- add receive-items controller and route for item transfers
- support moving ringball and inventory items in friend service

## Testing
- `npm test` (fails: no test specified)
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6892d86230b8833282da3124f8d66a8c