### PR TITLE
feat: add friend list retrieval endpoint

### DIFF
--- a/src/controllers/friendController.ts
+++ b/src/controllers/friendController.ts
@@ -5,6 +5,7 @@ import {
   respondFriendRequest,
   sendMessage,
   receiveItems,
+  getFriendList,
 } from '../services/friendService';
 
 export const sendFriendRequestController = async (
@@ -74,6 +75,27 @@ export const respondFriendRequestController = async (
     }
 
     const result = await respondFriendRequest(senderId, receiverId, accept);
+    if (result.success) {
+      res.json(result.data);
+      return;
+    }
+    res.status(400).json({ message: result.message });
+  } catch (error: any) {
+    res.status(500).json({ message: error.message });
+  }
+};
+
+export const getFriendListController = async (
+  req: Request,
+  res: Response
+): Promise<void> => {
+  try {
+    const playerId = Number(req.params.playerId);
+    if (isNaN(playerId)) {
+      res.status(400).json({ message: 'Invalid playerId' });
+      return;
+    }
+    const result = await getFriendList(playerId);
     if (result.success) {
       res.json(result.data);
       return;

--- a/src/routes/friendRoutes.ts
+++ b/src/routes/friendRoutes.ts
@@ -6,6 +6,7 @@ import {
   respondFriendRequestController,
   sendMessageController,
   receiveItemsController,
+  getFriendListController,
 } from '../controllers/friendController';
 
 const router = Router();
@@ -15,5 +16,6 @@ router.post('/friend-remove', removeFriendController);
 router.post('/friend-respond', respondFriendRequestController);
 router.post('/send-message', sendMessageController);
 router.post('/receive-items', receiveItemsController);
+router.get('/friend-list/:playerId', getFriendListController);
 
 export default router;

--- a/src/services/friendService.ts
+++ b/src/services/friendService.ts
@@ -1,4 +1,5 @@
 import prisma from '../models/prismaClient';
+import { getPlayerByListId } from './playerService';
 
 export const sendFriendRequest = async (senderId: number, receiverId: number) => {
   try {
@@ -68,6 +69,23 @@ export const respondFriendRequest = async (
     }
 
     return { success: true, data: request };
+  } catch (error: any) {
+    return { success: false, message: error.message };
+  }
+};
+
+export const getFriendList = async (playerId: number) => {
+  try {
+    const friendships = await prisma.friendship.findMany({
+      where: { playerId },
+      select: { friendId: true },
+    });
+    const friendIds = friendships.map((f) => f.friendId);
+    if (friendIds.length === 0) {
+      return { success: true, data: [] };
+    }
+    const players = await getPlayerByListId(friendIds);
+    return { success: true, data: players };
   } catch (error: any) {
     return { success: false, message: error.message };
   }


### PR DESCRIPTION
## Summary
- add service for retrieving a player's friends using existing player lookup
- expose controller and route to fetch a friend list by playerId

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run build`
- `curl -s http://localhost:5000/api/friend-list/1` *(fails: Can't reach database server at `localhost:5432`)*

------
https://chatgpt.com/codex/tasks/task_e_689373148488833296af32b76aa7703c