### PR TITLE
feat: add pending friend request retrieval

### DIFF
--- a/src/controllers/friendController.ts
+++ b/src/controllers/friendController.ts
@@ -6,6 +6,7 @@ import {
   sendMessage,
   receiveItems,
   getFriendList,
+  getPendingFriendRequests,
 } from '../services/friendService';
 
 export const sendFriendRequestController = async (
@@ -96,6 +97,27 @@ export const getFriendListController = async (
       return;
     }
     const result = await getFriendList(playerId);
+    if (result.success) {
+      res.json(result.data);
+      return;
+    }
+    res.status(400).json({ message: result.message });
+  } catch (error: any) {
+    res.status(500).json({ message: error.message });
+  }
+};
+
+export const getPendingFriendRequestsController = async (
+  req: Request,
+  res: Response
+): Promise<void> => {
+  try {
+    const receiverId = Number(req.params.receiverId);
+    if (isNaN(receiverId)) {
+      res.status(400).json({ message: 'Invalid receiverId' });
+      return;
+    }
+    const result = await getPendingFriendRequests(receiverId);
     if (result.success) {
       res.json(result.data);
       return;

--- a/src/routes/friendRoutes.ts
+++ b/src/routes/friendRoutes.ts
@@ -7,6 +7,7 @@ import {
   sendMessageController,
   receiveItemsController,
   getFriendListController,
+  getPendingFriendRequestsController,
 } from '../controllers/friendController';
 
 const router = Router();
@@ -17,5 +18,6 @@ router.post('/friend-respond', respondFriendRequestController);
 router.post('/send-message', sendMessageController);
 router.post('/receive-items', receiveItemsController);
 router.get('/friend-list/:playerId', getFriendListController);
+router.get('/friend-requests/:receiverId', getPendingFriendRequestsController);
 
 export default router;

--- a/src/services/friendService.ts
+++ b/src/services/friendService.ts
@@ -91,6 +91,21 @@ export const getFriendList = async (playerId: number) => {
   }
 };
 
+export const getPendingFriendRequests = async (
+  receiverId: number
+) => {
+  try {
+    const requests = await prisma.friendRequest.findMany({
+      where: { receiverId, status: 'PENDING' },
+      include: { sender: true },
+    });
+    const senders = requests.map((r) => r.sender);
+    return { success: true, data: senders };
+  } catch (error: any) {
+    return { success: false, message: error.message };
+  }
+};
+
 export const sendMessage = async (
   senderId: number,
   receiverId: number,


### PR DESCRIPTION
## Summary
- add service for retrieving pending friend requests with sender details
- expose controller and route to fetch pending requests

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run build` *(fails: type errors in existing code)*

------
https://chatgpt.com/codex/tasks/task_e_6893fcc07c148332a340202069be6f4e