### PR TITLE
feat: add friend message retrieval

### DIFF
--- a/src/controllers/friendController.ts
+++ b/src/controllers/friendController.ts
@@ -7,6 +7,7 @@ import {
   receiveItems,
   getFriendList,
   getPendingFriendRequests,
+  getFriendMessages,
 } from '../services/friendService';
 
 export const sendFriendRequestController = async (
@@ -118,6 +119,27 @@ export const getPendingFriendRequestsController = async (
       return;
     }
     const result = await getPendingFriendRequests(receiverId);
+    if (result.success) {
+      res.json(result.data);
+      return;
+    }
+    res.status(400).json({ message: result.message });
+  } catch (error: any) {
+    res.status(500).json({ message: error.message });
+  }
+};
+
+export const getFriendMessagesController = async (
+  req: Request,
+  res: Response
+): Promise<void> => {
+  try {
+    const receiverId = Number(req.params.receiverId);
+    if (isNaN(receiverId)) {
+      res.status(400).json({ message: 'Invalid receiverId' });
+      return;
+    }
+    const result = await getFriendMessages(receiverId);
     if (result.success) {
       res.json(result.data);
       return;

--- a/src/routes/friendRoutes.ts
+++ b/src/routes/friendRoutes.ts
@@ -8,6 +8,7 @@ import {
   receiveItemsController,
   getFriendListController,
   getPendingFriendRequestsController,
+  getFriendMessagesController,
 } from '../controllers/friendController';
 
 const router = Router();
@@ -19,5 +20,6 @@ router.post('/send-message', sendMessageController);
 router.post('/receive-items', receiveItemsController);
 router.get('/friend-list/:playerId', getFriendListController);
 router.get('/friend-requests/:receiverId', getPendingFriendRequestsController);
+router.get('/messages/:receiverId', getFriendMessagesController);
 
 export default router;

--- a/src/services/friendService.ts
+++ b/src/services/friendService.ts
@@ -106,6 +106,18 @@ export const getPendingFriendRequests = async (
   }
 };
 
+export const getFriendMessages = async (receiverId: number) => {
+  try {
+    const messages = await prisma.friendMessage.findMany({
+      where: { receiverId },
+      include: { sender: true },
+    });
+    return { success: true, data: messages };
+  } catch (error: any) {
+    return { success: false, message: error.message };
+  }
+};
+
 export const sendMessage = async (
   senderId: number,
   receiverId: number,


### PR DESCRIPTION
## Summary
- enable fetching friend messages with sender details
- expose controller to return messages by receiver
- add route for retrieving friend messages

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run build` *(fails: Type '{ senderId: number; receiverId: number; message: string; itemId: number; seqId: number; }' is not assignable to type '...')*

------
https://chatgpt.com/codex/tasks/task_e_6893fe64c8ec8332964580547723e47a