### PR TITLE
Mark friend messages as read when items received

### DIFF
--- a/src/controllers/friendController.ts
+++ b/src/controllers/friendController.ts
@@ -199,6 +199,8 @@ export const receiveItemsController = async (
     const senderId = Number(req.body.senderId ?? req.params.senderId);
     const receiverId = Number(req.body.receiverId ?? req.params.receiverId);
     const items = req.body.items;
+    const seqMess =
+      req.body.seqMess !== undefined ? Number(req.body.seqMess) : undefined;
 
     if (
       isNaN(senderId) ||
@@ -211,6 +213,7 @@ export const receiveItemsController = async (
           !isNaN(Number(it.itemId)) &&
           !isNaN(Number(it.seq))
       )
+      || (seqMess !== undefined && isNaN(seqMess))
     ) {
       res.status(400).json({ message: 'Invalid parameters' });
       return;
@@ -221,7 +224,12 @@ export const receiveItemsController = async (
       seq: Number(it.seq),
     }));
 
-    const result = await receiveItems(senderId, receiverId, parsedItems);
+    const result = await receiveItems(
+      senderId,
+      receiverId,
+      parsedItems,
+      seqMess
+    );
     if (result.success) {
       res.json(result);
       return;

--- a/src/services/friendService.ts
+++ b/src/services/friendService.ts
@@ -126,8 +126,14 @@ export const sendMessage = async (
   seqId?: number
 ) => {
   try {
+    const last = await prisma.friendMessage.findFirst({
+      where: { senderId },
+      orderBy: { seqMess: 'desc' },
+      select: { seqMess: true },
+    });
+    const seqMess = last ? last.seqMess + 1 : 0;
     const msg = await prisma.friendMessage.create({
-      data: { senderId, receiverId, message, itemId, seqId },
+      data: { senderId, receiverId, message, itemId, seqId, seqMess },
     });
     return { success: true, data: msg };
   } catch (error: any) {
@@ -138,10 +144,20 @@ export const sendMessage = async (
 export const receiveItems = async (
   senderId: number,
   receiverId: number,
-  items: Array<{ itemId: number; seq: number }>
+  items: Array<{ itemId: number; seq: number }>,
+  seqMess?: number
 ) => {
   try {
     await prisma.$transaction(async (tx) => {
+      await tx.friendMessage.updateMany({
+        where: {
+          senderId,
+          receiverId,
+          ...(seqMess !== undefined ? { seqMess } : {}),
+        },
+        data: { status: 'READ' },
+      });
+
       for (const { itemId, seq } of items) {
         if (itemId === 0) {
           const quantity = seq;


### PR DESCRIPTION
## Summary
- Mark friend messages as READ when items are received, optionally scoped by a provided seqMess identifier.
- Pass seqMess from controller to service and validate it.
- Auto-assign sequential seqMess when sending new friend messages.

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689401360d8c8332963813912483788e