### PR TITLE
Limit friend messages and propagate errors

### DIFF
--- a/src/controllers/friendController.ts
+++ b/src/controllers/friendController.ts
@@ -154,40 +154,38 @@ export const sendMessageController = async (
   req: Request,
   res: Response
 ): Promise<void> => {
+  const senderId = Number(req.body.senderId ?? req.params.senderId);
+  const receiverId = Number(req.body.receiverId ?? req.params.receiverId);
+  const { message } = req.body;
+  const itemId =
+    req.body.itemId !== undefined ? Number(req.body.itemId) : undefined;
+  const seqId =
+    req.body.seqId !== undefined ? Number(req.body.seqId) : undefined;
+
+  if (
+    isNaN(senderId) ||
+    isNaN(receiverId) ||
+    typeof message !== 'string' ||
+    (itemId !== undefined && isNaN(itemId)) ||
+    (seqId !== undefined && isNaN(seqId))
+  ) {
+    res.status(400).json({ message: 'Invalid parameters' });
+    return;
+  }
+
   try {
-    const senderId = Number(req.body.senderId ?? req.params.senderId);
-    const receiverId = Number(req.body.receiverId ?? req.params.receiverId);
-    const { message } = req.body;
-    const itemId =
-      req.body.itemId !== undefined ? Number(req.body.itemId) : undefined;
-    const seqId =
-      req.body.seqId !== undefined ? Number(req.body.seqId) : undefined;
-
-    if (
-      isNaN(senderId) ||
-      isNaN(receiverId) ||
-      typeof message !== 'string' ||
-      (itemId !== undefined && isNaN(itemId)) ||
-      (seqId !== undefined && isNaN(seqId))
-    ) {
-      res.status(400).json({ message: 'Invalid parameters' });
-      return;
-    }
-
-    const result = await sendMessage(
+    const msg = await sendMessage(
       senderId,
       receiverId,
       message,
       itemId,
       seqId
     );
-    if (result.success) {
-      res.json(result.data);
-      return;
-    }
-    res.status(400).json({ message: result.message });
+    res.json(msg);
   } catch (error: any) {
-    res.status(500).json({ message: error.message });
+    const status =
+      error.message === 'Message limit reached' ? 400 : 500;
+    res.status(status).json({ message: error.message });
   }
 };
 

--- a/src/services/friendService.ts
+++ b/src/services/friendService.ts
@@ -125,20 +125,25 @@ export const sendMessage = async (
   itemId?: number,
   seqId?: number
 ) => {
-  try {
-    const last = await prisma.friendMessage.findFirst({
-      where: { senderId },
-      orderBy: { seqMess: 'desc' },
-      select: { seqMess: true },
-    });
-    const seqMess = last ? last.seqMess + 1 : 0;
-    const msg = await prisma.friendMessage.create({
-      data: { senderId, receiverId, message, itemId, seqId, seqMess },
-    });
-    return { success: true, data: msg };
-  } catch (error: any) {
-    return { success: false, message: error.message };
+  const messageCount = await prisma.friendMessage.count({
+    where: { senderId },
+  });
+
+  if (messageCount >= 100) {
+    throw new Error('Message limit reached');
   }
+
+  const last = await prisma.friendMessage.findFirst({
+    where: { senderId },
+    orderBy: { seqMess: 'desc' },
+    select: { seqMess: true },
+  });
+
+  const seqMess = (last?.seqMess ?? 0) + 1;
+
+  return prisma.friendMessage.create({
+    data: { senderId, receiverId, message, itemId, seqId, seqMess },
+  });
 };
 
 export const receiveItems = async (


### PR DESCRIPTION
## Summary
- enforce a 100-message cap per sender and assign sequential message numbers
- return new message directly and raise errors for limit breaches
- update controller to surface service errors with appropriate status codes

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68940419855c8332b1abd6ce084f4145