### PR TITLE
Handle friend message limits and seq numbers

### DIFF
--- a/src/controllers/friendController.ts
+++ b/src/controllers/friendController.ts
@@ -174,18 +174,22 @@ export const sendMessageController = async (
   }
 
   try {
-    const msg = await sendMessage(
+    const result = await sendMessage(
       senderId,
       receiverId,
       message,
       itemId,
       seqId
     );
-    res.json(msg);
-  } catch (error: any) {
+    if (result.success) {
+      res.json(result.data);
+      return;
+    }
     const status =
-      error.message === 'Message limit reached' ? 400 : 500;
-    res.status(status).json({ message: error.message });
+      result.message === 'Message limit reached' ? 400 : 500;
+    res.status(status).json({ message: result.message });
+  } catch (error: any) {
+    res.status(500).json({ message: error.message });
   }
 };
 

--- a/src/services/friendService.ts
+++ b/src/services/friendService.ts
@@ -125,25 +125,31 @@ export const sendMessage = async (
   itemId?: number,
   seqId?: number
 ) => {
-  const messageCount = await prisma.friendMessage.count({
-    where: { senderId },
-  });
+  try {
+    const messageCount = await prisma.friendMessage.count({
+      where: { senderId },
+    });
 
-  if (messageCount >= 100) {
-    throw new Error('Message limit reached');
+    if (messageCount >= 100) {
+      throw new Error('Message limit reached');
+    }
+
+    const last = await prisma.friendMessage.findFirst({
+      where: { senderId },
+      orderBy: { seqMess: 'desc' },
+      select: { seqMess: true },
+    });
+
+    const seqMess = (last?.seqMess ?? 0) + 1;
+
+    const msg = await prisma.friendMessage.create({
+      data: { senderId, receiverId, message, itemId, seqId, seqMess },
+    });
+
+    return { success: true, data: msg };
+  } catch (error: any) {
+    return { success: false, message: error.message };
   }
-
-  const last = await prisma.friendMessage.findFirst({
-    where: { senderId },
-    orderBy: { seqMess: 'desc' },
-    select: { seqMess: true },
-  });
-
-  const seqMess = (last?.seqMess ?? 0) + 1;
-
-  return prisma.friendMessage.create({
-    data: { senderId, receiverId, message, itemId, seqId, seqMess },
-  });
 };
 
 export const receiveItems = async (


### PR DESCRIPTION
## Summary
- Enforce per-sender friend message limit and sequential numbering
- Return structured results from sendMessage for better error reporting
- Controller now interprets service results to respond with clear status codes

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6894079019148332bc2c0de98d386f0e