### PR TITLE
Handle friend challenge routing

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -90,8 +90,34 @@ if (cluster.isPrimary) {
           ws.send(JSON.stringify({ type: 'error', message: 'Player is offline' }));
         }
       } else if (data.type === 'friend_challenge') {
-        const challengeMessage = { type: 'friend_challenge_response', message: 'Challenge received!' };
-        ws.send(JSON.stringify(challengeMessage));
+        const { senderId, receiverId, bet } = data;
+
+        if (!senderId || !receiverId || typeof bet === 'undefined') {
+          ws.send(
+            JSON.stringify({
+              type: 'error',
+              message: 'senderId, receiverId, and bet are required for friend_challenge',
+            }),
+          );
+          return;
+        }
+
+        const target = players.get(receiverId);
+        if (target) {
+          target.send(
+            JSON.stringify({ type: 'friend_challenge', senderId, bet })
+          );
+          ws.send(
+            JSON.stringify({
+              type: 'friend_challenge_ack',
+              message: 'Challenge delivered',
+            })
+          );
+        } else {
+          ws.send(
+            JSON.stringify({ type: 'error', message: 'Player is offline' })
+          );
+        }
       }
     });
 


### PR DESCRIPTION
## Summary
- handle `friend_challenge` messages by parsing sender/receiver/bet and routing to the target player
- notify sender when the challenge is delivered or receiver is offline

## Testing
- `npm test` (fails: Error: no test specified)
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689409b638408332a35ea46657cd74d5