### PR TITLE
refactor websocket handlers

### DIFF
--- a/src/websocket/handlers.ts
+++ b/src/websocket/handlers.ts
@@ -1,0 +1,142 @@
+import WebSocket from 'ws';
+
+export type PlayerMap = Map<string, WebSocket>;
+
+export interface HandlerContext {
+  playerId: string | null;
+}
+
+type MessageHandler = (
+  ws: WebSocket,
+  players: PlayerMap,
+  data: any,
+  context: HandlerContext
+) => void;
+
+export const handleRegister: MessageHandler = (ws, players, data, context) => {
+  const { playerId } = data;
+  if (!playerId) {
+    ws.send(
+      JSON.stringify({ type: 'error', message: 'playerId is required for register' })
+    );
+    return;
+  }
+  context.playerId = playerId;
+  players.set(playerId, ws);
+};
+
+export const handleGetOnlinePlayers: MessageHandler = (ws, players) => {
+  const onlineIds = Array.from(players.keys());
+  ws.send(JSON.stringify({ type: 'online_players', playerIds: onlineIds }));
+};
+
+export const handleInvite: MessageHandler = (ws, players, data) => {
+  const { playerId } = data;
+  if (!playerId) {
+    ws.send(
+      JSON.stringify({ type: 'error', message: 'playerId is required for invite' })
+    );
+    return;
+  }
+  const target = players.get(playerId);
+  if (target) {
+    target.send(
+      JSON.stringify({ type: 'invite', message: 'You have a new friend invite!' })
+    );
+  } else {
+    ws.send(JSON.stringify({ type: 'error', message: 'Player is offline' }));
+  }
+};
+
+export const handleFriendChallenge: MessageHandler = (ws, players, data) => {
+  const senderId = String(data.senderId);
+  const receiverId = String(data.receiverId);
+  const bet = data.bet;
+  if (!senderId || !receiverId || typeof bet === 'undefined') {
+    ws.send(
+      JSON.stringify({
+        type: 'error',
+        message: 'senderId, receiverId, and bet are required for friend_challenge',
+      })
+    );
+    return;
+  }
+
+  const target = players.get(receiverId);
+  if (target) {
+    target.send(JSON.stringify({ type: 'friend_challenge', senderId, bet }));
+  } else {
+    ws.send(JSON.stringify({ type: 'error', message: 'Player is offline' }));
+  }
+};
+
+export const handleFriendChallengeResponse: MessageHandler = (
+  ws,
+  players,
+  data,
+  context
+) => {
+  const { senderId, receiverId, bet, accepted } = data;
+  if (
+    !senderId ||
+    !receiverId ||
+    typeof bet === 'undefined' ||
+    typeof accepted === 'undefined'
+  ) {
+    ws.send(
+      JSON.stringify({
+        type: 'error',
+        message:
+          'senderId, receiverId, bet, and accepted are required for friend_challenge_response',
+      })
+    );
+    return;
+  }
+  if (senderId !== context.playerId) {
+    ws.send(
+      JSON.stringify({
+        type: 'error',
+        message: 'senderId does not match current player',
+      })
+    );
+    return;
+  }
+  const target = players.get(receiverId);
+  if (target) {
+    target.send(
+      JSON.stringify({
+        type: 'friend_challenge_response',
+        senderId,
+        bet,
+        accepted,
+      })
+    );
+  } else {
+    ws.send(JSON.stringify({ type: 'error', message: 'Player is offline' }));
+  }
+};
+
+const handlers: Record<string, MessageHandler> = {
+  register: handleRegister,
+  get_online_players: handleGetOnlinePlayers,
+  invite: handleInvite,
+  friend_challenge: handleFriendChallenge,
+  friend_challenge_response: handleFriendChallengeResponse,
+};
+
+export const handleMessage = (
+  ws: WebSocket,
+  players: PlayerMap,
+  data: any,
+  context: HandlerContext
+) => {
+  const handler = handlers[data.type];
+  if (handler) {
+    handler(ws, players, data, context);
+  } else {
+    ws.send(JSON.stringify({ type: 'error', message: 'Unknown message type' }));
+  }
+};
+
+export type { MessageHandler };
+

--- a/src/websocket/server.ts
+++ b/src/websocket/server.ts
@@ -1,5 +1,6 @@
 import http from 'http';
 import WebSocket, { Server } from 'ws';
+import { handleMessage, HandlerContext } from './handlers';
 
 export const initWebSocketServer = (apiServer: http.Server, wsPort: number) => {
   const wss: Server = new WebSocket.Server({ noServer: true });
@@ -8,7 +9,7 @@ export const initWebSocketServer = (apiServer: http.Server, wsPort: number) => {
   wss.on('connection', (ws: WebSocket) => {
     console.log('A new WebSocket client connected!');
 
-    let playerId: string | null = null;
+    const context: HandlerContext = { playerId: null };
 
     ws.on('message', (message: string) => {
       console.log('Received: %s', message);
@@ -20,99 +21,11 @@ export const initWebSocketServer = (apiServer: http.Server, wsPort: number) => {
         return;
       }
 
-      if (data.type === 'register') {
-        playerId = data.playerId;
-        players.set(playerId, ws);
-      } else if (data.type === 'get_online_players') {
-        const onlineIds = Array.from(players.keys());
-        ws.send(JSON.stringify({ type: 'online_players', playerIds: onlineIds }));
-      } else if (data.type === 'invite') {
-        if (!data.playerId) {
-          ws.send(JSON.stringify({ type: 'error', message: 'playerId is required for invite' }));
-          return;
-        }
-        const target = players.get(data.playerId);
-        if (target) {
-          target.send(
-            JSON.stringify({ type: 'invite', message: 'You have a new friend invite!' })
-          );
-        } else {
-          ws.send(JSON.stringify({ type: 'error', message: 'Player is offline' }));
-        }
-      } else if (data.type === 'friend_challenge') {
-        const senderId = String(data.senderId);
-        const receiverId = String(data.receiverId);
-        const bet = data.bet;
-        if (!senderId || !receiverId || typeof bet === 'undefined') {
-          ws.send(
-            JSON.stringify({
-              type: 'error',
-              message:
-                'senderId, receiverId, and bet are required for friend_challenge',
-            })
-          );
-          return;
-        }
-
-        const target = players.get(receiverId);
-        if (target) {
-          target.send(
-            JSON.stringify({ type: 'friend_challenge', senderId, bet })
-          );
-        } else {
-          ws.send(
-            JSON.stringify({ type: 'error', message: 'Player is offline' })
-          );
-        }
-      } else if (data.type === 'friend_challenge_response') {
-        const { senderId, receiverId, bet, accepted } = data;
-
-        if (
-          !senderId ||
-          !receiverId ||
-          typeof bet === 'undefined' ||
-          typeof accepted === 'undefined'
-        ) {
-          ws.send(
-            JSON.stringify({
-              type: 'error',
-              message:
-                'senderId, receiverId, bet, and accepted are required for friend_challenge_response',
-            })
-          );
-          return;
-        }
-
-        if (senderId !== playerId) {
-          ws.send(
-            JSON.stringify({
-              type: 'error',
-              message: 'senderId does not match current player',
-            })
-          );
-          return;
-        }
-
-        const target = players.get(receiverId);
-        if (target) {
-          target.send(
-            JSON.stringify({
-              type: 'friend_challenge_response',
-              senderId,
-              bet,
-              accepted,
-            })
-          );
-        } else {
-          ws.send(
-            JSON.stringify({ type: 'error', message: 'Player is offline' })
-          );
-        }
-      }
+      handleMessage(ws, players, data, context);
     });
 
     ws.on('close', () => {
-      if (playerId) players.delete(playerId);
+      if (context.playerId) players.delete(context.playerId);
     });
 
     const welcomeMessage = { type: 'welcome', message: 'Welcome to the game server!' };


### PR DESCRIPTION
## Summary
- add dedicated WebSocket message handlers and dispatcher
- refactor server to use handler map for cleaner message routing

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689542a4fb948332a4499ceaa373be46