### PR TITLE
feat: add player online check in websocket

### DIFF
--- a/src/websocket/handlers.ts
+++ b/src/websocket/handlers.ts
@@ -4,6 +4,7 @@ export type PlayerMap = Map<string, WebSocket>;
 
 export interface HandlerContext {
   playerId: string | null;
+  isPlayerOnline: (playerId: string) => boolean;
 }
 
 type MessageHandler = (
@@ -30,7 +31,7 @@ export const handleGetOnlinePlayers: MessageHandler = (ws, players) => {
   ws.send(JSON.stringify({ type: 'online_players', playerIds: onlineIds }));
 };
 
-export const handleInvite: MessageHandler = (ws, players, data) => {
+export const handleInvite: MessageHandler = (ws, players, data, context) => {
   const { playerId } = data;
   if (!playerId) {
     ws.send(
@@ -38,9 +39,9 @@ export const handleInvite: MessageHandler = (ws, players, data) => {
     );
     return;
   }
-  const target = players.get(playerId);
-  if (target) {
-    target.send(
+  if (context.isPlayerOnline(playerId)) {
+    const target = players.get(playerId);
+    target?.send(
       JSON.stringify({ type: 'invite', message: 'You have a new friend invite!' })
     );
   } else {
@@ -48,7 +49,7 @@ export const handleInvite: MessageHandler = (ws, players, data) => {
   }
 };
 
-export const handleFriendChallenge: MessageHandler = (ws, players, data) => {
+export const handleFriendChallenge: MessageHandler = (ws, players, data, context) => {
   const senderId = String(data.senderId);
   const receiverId = String(data.receiverId);
   const bet = data.bet;
@@ -62,9 +63,9 @@ export const handleFriendChallenge: MessageHandler = (ws, players, data) => {
     return;
   }
 
-  const target = players.get(receiverId);
-  if (target) {
-    target.send(JSON.stringify({ type: 'friend_challenge', senderId, bet }));
+  if (context.isPlayerOnline(receiverId)) {
+    const target = players.get(receiverId);
+    target?.send(JSON.stringify({ type: 'friend_challenge', senderId, bet }));
   } else {
     ws.send(JSON.stringify({ type: 'error', message: 'Player is offline' }));
   }
@@ -101,9 +102,9 @@ export const handleFriendChallengeResponse: MessageHandler = (
     );
     return;
   }
-  const target = players.get(receiverId);
-  if (target) {
-    target.send(
+  if (context.isPlayerOnline(receiverId)) {
+    const target = players.get(receiverId);
+    target?.send(
       JSON.stringify({
         type: 'friend_challenge_response',
         senderId,

--- a/src/websocket/server.ts
+++ b/src/websocket/server.ts
@@ -9,7 +9,10 @@ export const initWebSocketServer = (apiServer: http.Server, wsPort: number) => {
   wss.on('connection', (ws: WebSocket) => {
     console.log('A new WebSocket client connected!');
 
-    const context: HandlerContext = { playerId: null };
+    const context: HandlerContext = {
+      playerId: null,
+      isPlayerOnline: (id) => players.has(id),
+    };
 
     ws.on('message', (message: string) => {
       console.log('Received: %s', message);


### PR DESCRIPTION
## Summary
- track whether a player is online via a new `isPlayerOnline` method in the WebSocket handler context
- use the online check for invites and challenges

## Testing
- `npm run build`
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6895472991b88332a728b2cff09ffe1b