### PR TITLE
feat: add friend search by ID

### DIFF
--- a/src/controllers/friendController.ts
+++ b/src/controllers/friendController.ts
@@ -9,7 +9,38 @@ import {
   getFriendList,
   getPendingFriendRequests,
   getFriendMessages,
+  searchPlayerById,
 } from '../services/friendService';
+
+export const searchPlayerByIdController = async (
+  req: Request,
+  res: Response
+): Promise<void> => {
+  try {
+    const raw =
+      (req.params.id as string | undefined) ??
+      (req.query.search as string | undefined);
+    if (raw === undefined) {
+      res.status(400).json({ message: 'Invalid id' });
+      return;
+    }
+
+    const id = Number(raw);
+    if (isNaN(id) || String(id) !== raw) {
+      res.status(400).json({ message: 'Invalid id' });
+      return;
+    }
+
+    const result = await searchPlayerById(id);
+    if (result.success) {
+      res.json(result.data);
+      return;
+    }
+    res.status(404).json({ message: result.message });
+  } catch (error: any) {
+    res.status(500).json({ message: error.message });
+  }
+};
 
 export const sendFriendRequestController = async (
   req: Request,

--- a/src/routes/friendRoutes.ts
+++ b/src/routes/friendRoutes.ts
@@ -10,6 +10,7 @@ import {
   getPendingFriendRequestsController,
   getFriendMessagesController,
   deleteFriendMessageController,
+  searchPlayerByIdController,
 } from '../controllers/friendController';
 
 const router = Router();
@@ -19,6 +20,7 @@ router.post('/friend-remove', removeFriendController);
 router.post('/friend-respond', respondFriendRequestController);
 router.post('/send-message', sendMessageController);
 router.post('/receive-items', receiveItemsController);
+router.get('/friend-search/:id', searchPlayerByIdController);
 router.get('/friend-list/:playerId', getFriendListController);
 router.get('/friend-requests/:receiverId', getPendingFriendRequestsController);
 router.get('/messages/:receiverId', getFriendMessagesController);

--- a/src/services/friendService.ts
+++ b/src/services/friendService.ts
@@ -1,6 +1,20 @@
 import prisma from '../models/prismaClient';
 import { getPlayerByListId } from './playerService';
 
+export const searchPlayerById = async (id: number) => {
+  try {
+    const player = await prisma.player.findUnique({
+      where: { id, IsActive: true },
+    });
+    if (!player) {
+      return { success: false, message: 'Player not found' };
+    }
+    return { success: true, data: player };
+  } catch (error: any) {
+    return { success: false, message: error.message };
+  }
+};
+
 export const sendFriendRequest = async (senderId: number, receiverId: number) => {
   try {
     const alreadyFriend = await prisma.friendship.findFirst({


### PR DESCRIPTION
## Summary
- add service to search active players by id
- wire up controller and route for friend search endpoint

## Testing
- `npm test` (fails: Error: no test specified)
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68969b10440483328b810373d177087b