### PR TITLE
feat: add friend code to account creation

### DIFF
--- a/src/services/playerService.ts
+++ b/src/services/playerService.ts
@@ -4,6 +4,16 @@ import prisma from '../models/prismaClient'; // Import Prisma Client
 // Location id used in EquipPlayer to mark the equipped ball slot
 const BALL_SLOT_LOCATION_ID = 2;
 
+const generateFriendCode = (): string => {
+  const chars = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789';
+  const length = Math.floor(Math.random() * 3) + 8; // 8-10 characters
+  let code = '';
+  for (let i = 0; i < length; i++) {
+    code += chars.charAt(Math.floor(Math.random() * chars.length));
+  }
+  return code;
+};
+
 export const getPlayerByAccountId = async (accountId: string) => {
   return await prisma.player.findFirst({
     where: { IdAccount: accountId, IsActive: true },
@@ -197,78 +207,90 @@ export const equipPlayerItem = async (
 };
 
 export const createAccount = async (idToken: string, playerName: string) => {
-  return prisma.$transaction(async (tx) => {
-    const existing = await tx.player.findFirst({
-      where: { IdAccount: idToken, IsActive: true },
-    });
+  const MAX_ATTEMPTS = 5;
+  for (let attempt = 0; attempt < MAX_ATTEMPTS; attempt++) {
+    try {
+      return await prisma.$transaction(async (tx) => {
+        const existing = await tx.player.findFirst({
+          where: { IdAccount: idToken, IsActive: true },
+        });
 
-    if (existing) {
-      return existing;
+        if (existing) {
+          return existing;
+        }
+
+        const player = await tx.player.create({
+          data: {
+            friendCode: generateFriendCode(),
+            IdAccount: idToken,
+            PlayerName: playerName,
+            Level: 1,
+            Exp: 0,
+            Body: 1,
+            RingBall: 20,
+            Money: 0,
+            TalentPoint: 0,
+            IsActive: true,
+          },
+        });
+
+        await tx.playerItem.create({
+          data: {
+            playerId: player.id,
+            itemId: 99000001,
+            seq: 0,
+            level: 1,
+            description: '',
+            Price: 0,
+            IsSolded: 3,
+          },
+        });
+
+        await tx.equipPlayer.create({
+          data: {
+            playerId: player.id,
+            locationId: 1,
+            itemId: 99000001,
+            seqItem: 0,
+            createdDate: new Date(),
+          },
+        });
+
+        const effects = [
+          { effectId: 11000001, power: 0.0, spin: 0, isPassive: true, charges: 0 },
+          { effectId: 11000002, power: 0, spin: 0.5, isPassive: true, charges: 0 },
+          { effectId: 11000003, power: 0, spin: 0, isPassive: true, charges: 0 },
+          { effectId: 11000004, power: 0, spin: 0, isPassive: true, charges: 0 },
+          { effectId: 11000005, power: 0, spin: 0, isPassive: true, charges: 0 },
+          { effectId: 11000006, power: 0, spin: 0, isPassive: true, charges: 0 },
+          { effectId: 11000007, power: 0, spin: 0, isPassive: false, charges: 0 },
+          { effectId: 11000008, power: 0, spin: 0, isPassive: false, charges: 0 },
+        ];
+
+        await tx.effectPlayer.createMany({
+          data: effects.map((effect) => ({
+            playerId: player.id,
+            effectId: effect.effectId,
+            power: effect.power,
+            spin: effect.spin,
+            level: 1, // Mặc định level ban đầu là 1
+            isPassive: effect.isPassive,
+            charges: effect.charges,
+            description: `Skill ${effect.effectId}`, // Mô tả kỹ năng
+          })),
+        });
+
+        return player;
+      });
+    } catch (error: any) {
+      if (error.code === 'P2002') {
+        continue; // Retry on unique constraint violation
+      }
+      throw error;
     }
-    const player = await tx.player.create({
-      data: {
+  }
 
-        IdAccount: idToken,
-        PlayerName: playerName,
-        Level: 1,
-        Exp: 0,
-        Body: 1,
-        RingBall: 20,
-        Money: 0,
-        TalentPoint: 0,
-        IsActive: true
-      },
-    });
-
-    await tx.playerItem.create({
-      data: {
-        playerId: player.id,
-        itemId: 99000001,
-        seq: 0,
-        level: 1,
-        description: '',
-        Price: 0,
-        IsSolded: 3,
-      },
-    });
-
-    await tx.equipPlayer.create({
-      data: {
-        playerId: player.id,
-        locationId: 1,
-        itemId: 99000001,
-        seqItem: 0,
-        createdDate: new Date(),
-      },
-    });
-
-const effects = [
-      { effectId: 11000001, power: 0.0, spin: 0, isPassive: true, charges: 0 },
-      { effectId: 11000002, power: 0, spin: 0.5, isPassive: true, charges: 0 },
-      { effectId: 11000003, power: 0, spin: 0, isPassive: true, charges: 0 },
-      { effectId: 11000004, power: 0, spin: 0, isPassive: true, charges: 0 },
-      { effectId: 11000005, power: 0, spin: 0, isPassive: true, charges: 0 },
-      { effectId: 11000006, power: 0, spin: 0, isPassive: true, charges: 0 },
-      { effectId: 11000007, power: 0, spin: 0, isPassive: false, charges: 0 },
-      { effectId: 11000008, power: 0, spin: 0, isPassive: false, charges: 0 },
-    ];
-
-   await tx.effectPlayer.createMany({
-      data: effects.map((effect) => ({
-        playerId: player.id,
-        effectId: effect.effectId,
-        power: effect.power,
-        spin: effect.spin,
-        level: 1, // Mặc định level ban đầu là 1
-        isPassive: effect.isPassive,
-        charges: effect.charges,
-        description: `Skill ${effect.effectId}`, // Mô tả kỹ năng
-      })),
-    });
-
-
-    return player;
-  });
+  throw new Error('Failed to create account');
 };
 
 


### PR DESCRIPTION
## Summary
- generate random alphanumeric friend codes for new players
- retry account creation on friend code collision within transaction

## Testing
- `npm test` (fails: Error: no test specified)
- `npm run build` (fails: Cannot find module 'express' or its corresponding type declarations)


------
https://chatgpt.com/codex/tasks/task_e_6896e511dfd0833280e4a171e0586a12