### PR TITLE
Use friend code for friend requests

### DIFF
--- a/ReadMe
+++ b/ReadMe
@@ -24,6 +24,7 @@ POST /api/player/equip - Trang bị vật phẩm cho người chơi
 POST /api/effect-player/item-level-up - Nâng cấp level của vật phẩm
 GET /api/histories?page=1&pageSize=10 - Lịch sử trận đấu (mặc định 10 bản ghi gần nhất, hỗ trợ phân trang)
 POST /api/draw-reward - Bốc thăm trúng thưởng (body: {"playerId": number})
+POST /api/friend-request - Gửi lời mời kết bạn (body: {"senderId": number, "friendCode": string})
 GET /api/market/items?page=1&itemName=X&level=1&priceOrder=asc&levelOrder=desc - Danh sách vật phẩm bán trên chợ, hỗ trợ lọc và phân trang (mặc định 10 bản ghi mỗi trang)
 
 Body JSON /players/ball-physics:

--- a/src/controllers/friendController.ts
+++ b/src/controllers/friendController.ts
@@ -48,14 +48,15 @@ export const sendFriendRequestController = async (
 ): Promise<void> => {
   try {
     const senderId = Number(req.body.senderId ?? req.params.senderId);
-    const receiverId = Number(req.body.receiverId ?? req.params.receiverId);
+    const friendCode =
+      (req.body.friendCode ?? req.params.friendCode)?.toString();
 
-    if (isNaN(senderId) || isNaN(receiverId)) {
-      res.status(400).json({ message: 'Invalid senderId or receiverId' });
+    if (isNaN(senderId) || !friendCode) {
+      res.status(400).json({ message: 'Invalid senderId or friendCode' });
       return;
     }
 
-    const result = await sendFriendRequest(senderId, receiverId);
+    const result = await sendFriendRequest(senderId, friendCode);
     if (result.success) {
       res.json(result.data);
       return;

--- a/src/services/friendService.ts
+++ b/src/services/friendService.ts
@@ -15,18 +15,19 @@ export const searchPlayerById = async (id: number) => {
   }
 };
 
-export const sendFriendRequest = async (senderId: number, friendCode: number) => {
+export const sendFriendRequest = async (
+  senderId: number,
+  friendCode: string
+) => {
   try {
-            // Kiểm tra receiverId có tồn tại không
     const receiver = await prisma.player.findUnique({
-      where: { friendCode: friendCode, IsActive: true, NOT: {
-      id: senderId
-    } },
+      where: { friendCode, IsActive: true },
     });
-    if (!receiver) {
+    if (!receiver || receiver.id === BigInt(senderId)) {
       return { success: false, message: 'Receiver player not found' };
     }
-    // Kiểm tra xem senderId và receiverId có là bạn hay không
+    const receiverId = Number(receiver.id);
+
     const alreadyFriend = await prisma.friendship.findFirst({
       where: {
         OR: [
@@ -40,13 +41,17 @@ export const sendFriendRequest = async (senderId: number, friendCode: number) =>
     }
 
     const incoming = await prisma.friendRequest.findUnique({
-      where: { senderId_receiverId: { senderId: receiverId, receiverId: senderId } },
+      where: {
+        senderId_receiverId: { senderId: receiverId, receiverId: senderId },
+      },
     });
 
     if (incoming) {
       if (incoming.status === 'PENDING') {
         const updated = await prisma.friendRequest.update({
-          where: { senderId_receiverId: { senderId: receiverId, receiverId: senderId } },
+          where: {
+            senderId_receiverId: { senderId: receiverId, receiverId: senderId },
+          },
           data: { status: 'ACCEPTED' },
         });
         await prisma.friendship.createMany({
@@ -56,7 +61,11 @@ export const sendFriendRequest = async (senderId: number, friendCode: number) =>
           ],
           skipDuplicates: true,
         });
-        return { success: true, message: 'Friend request auto-accepted', data: updated };
+        return {
+          success: true,
+          message: 'Friend request auto-accepted',
+          data: updated,
+        };
       }
       return { success: false, message: 'Already handled' };
     }


### PR DESCRIPTION
## Summary
- accept friend requests using friend codes instead of receiver IDs
- look up receiver by friend code in service and perform friend checks with the found ID
- document friend request endpoint with friend code parameter

## Testing
- `npm run build`
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6896ea5734f083328784791ba40c66da