### PR TITLE
feat: add reward listing endpoint

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -13,6 +13,7 @@ import drawRoutes from './routes/drawRoutes';
 import marketRoutes from './routes/marketRoutes';
 import accountRoutes from './routes/accountRoutes';
 import friendRoutes from './routes/friendRoutes';
+import rewardRoutes from './routes/rewardRoutes';
 
 const app = express();
 
@@ -34,6 +35,7 @@ app.use('/api', drawRoutes);
 app.use('/api', marketRoutes);
 app.use('/api', accountRoutes);
 app.use('/api', friendRoutes);
+app.use('/api', rewardRoutes);
 
 // KHÔNG CÒN BẤT KỲ ĐOẠN app.listen() hay new WebSocket.Server() nào ở đây
 

--- a/src/controllers/rewardController.ts
+++ b/src/controllers/rewardController.ts
@@ -1,0 +1,34 @@
+import { Request, Response } from 'express';
+import { listRewards } from '../services/rewardService';
+
+export const getRewards = async (req: Request, res: Response) => {
+  try {
+    const { rewardType, playerId, dayofweek } = req.query;
+
+    if (typeof rewardType !== 'string' || typeof playerId !== 'string') {
+      res.status(400).json({ message: 'Missing or invalid rewardType or playerId' });
+      return;
+    }
+
+    const playerIdNum = Number(playerId);
+    if (isNaN(playerIdNum)) {
+      res.status(400).json({ message: 'Invalid playerId' });
+      return;
+    }
+
+    let dayOfWeekNum: number | undefined;
+    if (dayofweek !== undefined) {
+      const dayStr = Array.isArray(dayofweek) ? dayofweek[0] : dayofweek;
+      dayOfWeekNum = Number(dayStr);
+      if (isNaN(dayOfWeekNum)) {
+        res.status(400).json({ message: 'Invalid dayofweek' });
+        return;
+      }
+    }
+
+    const rewards = await listRewards(rewardType, playerIdNum, dayOfWeekNum);
+    res.json(rewards);
+  } catch (error: any) {
+    res.status(500).json({ message: error.message });
+  }
+};

--- a/src/routes/rewardRoutes.ts
+++ b/src/routes/rewardRoutes.ts
@@ -1,0 +1,8 @@
+import { Router } from 'express';
+import * as RewardController from '../controllers/rewardController';
+
+const router = Router();
+
+router.get('/rewards', RewardController.getRewards);
+
+export default router;

--- a/src/services/rewardService.ts
+++ b/src/services/rewardService.ts
@@ -1,0 +1,37 @@
+import prisma from '../models/prismaClient';
+
+export const listRewards = async (
+  rewardType: string,
+  playerId: number,
+  dayOfWeek?: number,
+) => {
+  const rewards = await prisma.reward.findMany({
+    where: {
+      rewardType,
+      ...(dayOfWeek !== undefined ? { dayofweek: dayOfWeek } : {}),
+    },
+    include: {
+      achievements: {
+        include: {
+          playerAchievements: {
+            where: { playerId },
+            select: { achievedAt: true },
+          },
+        },
+      },
+    },
+  });
+
+  return rewards.map((reward) => ({
+    ...reward,
+    achievements: reward.achievements.map((ach) => ({
+      id: ach.id,
+      name: ach.name,
+      description: ach.description,
+      criteria: ach.criteria,
+      rewardId: ach.rewardId,
+      claimed: ach.playerAchievements.length > 0,
+      claimedAt: ach.playerAchievements[0]?.achievedAt || null,
+    })),
+  }));
+};


### PR DESCRIPTION
## Summary
- add reward service for listing rewards with claimed flags
- implement controller and route for querying rewards
- register reward routes in app

## Testing
- `npm run build`
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68a1614b1c34833293b852ecb5daee91