### PR TITLE
refactor: query player achievements for rewards

### DIFF
--- a/src/services/rewardService.ts
+++ b/src/services/rewardService.ts
@@ -5,22 +5,22 @@ export const listRewards = async (
   playerId: number,
   dayOfWeek?: number,
 ) => {
-  const rewards = await prisma.reward.findMany({
+  const achievements = await prisma.playerAchievement.findMany({
     where: {
       rewardType,
-      ...(dayOfWeek !== undefined ? { dayofweek: dayOfWeek } : {}),
+      playerId,
     },
-    include: {
-      playerAchievement: {
-        where: { playerId },
-        select: { achievedAt: true },
-      },
+    orderBy: {
+      seq: 'asc',
+    },
+    take: 20,
+    select: {
+      seq: true,
+      locationId: true,
+      itemId: true,
+      rewardAmount: true,
     },
   });
 
-  return rewards.map((reward) => ({
-    ...reward,
-    claimed: reward.playerAchievement.length > 0,
-    claimedAt: reward.playerAchievement[0]?.achievedAt ?? null,
-  }));
+  return achievements;
 };


### PR DESCRIPTION
## Summary
- replace reward lookup with playerAchievement query filtered by player and reward type
- return top 20 records ordered by sequence including locationId, itemId and rewardAmount

## Testing
- `npm run build`
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68a1adaecf348332b940dcc5363be903