### PR TITLE
feat: add reward refresh handler

### DIFF
--- a/src/controllers/rewardController.ts
+++ b/src/controllers/rewardController.ts
@@ -1,5 +1,5 @@
 import { Request, Response } from 'express';
-import { listRewards } from '../services/rewardService';
+import { listRewards, refreshRewards as refreshRewardsService } from '../services/rewardService';
 
 export const getRewards = async (req: Request, res: Response) => {
   try {
@@ -27,6 +27,27 @@ export const getRewards = async (req: Request, res: Response) => {
     }
 
     const rewards = await listRewards(rewardType, playerIdNum, dayOfWeekNum);
+    res.json(rewards);
+  } catch (error: any) {
+    res.status(500).json({ message: error.message });
+  }
+};
+
+export const refreshRewards = async (req: Request, res: Response) => {
+  try {
+    const playerIdParam = (req.query.playerId ?? req.body.playerId) as string | undefined;
+    if (playerIdParam === undefined) {
+      res.status(400).json({ message: 'Missing playerId' });
+      return;
+    }
+
+    const playerIdNum = Number(playerIdParam);
+    if (isNaN(playerIdNum)) {
+      res.status(400).json({ message: 'Invalid playerId' });
+      return;
+    }
+
+    const rewards = await refreshRewardsService(playerIdNum);
     res.json(rewards);
   } catch (error: any) {
     res.status(500).json({ message: error.message });

--- a/src/services/rewardService.ts
+++ b/src/services/rewardService.ts
@@ -24,3 +24,53 @@ export const listRewards = async (
 
   return achievements;
 };
+
+export const refreshRewards = async (playerId: number) => {
+  const rewardType = '11100001';
+
+  await prisma.playerAchievement.deleteMany({
+    where: { playerId, rewardType },
+  });
+
+  const locations = Array.from({ length: 20 }, (_, i) => i + 1);
+  const shuffled = [...locations].sort(() => Math.random() - 0.5);
+  const itemLocations = shuffled.slice(0, 3);
+  const rewardLocations = shuffled.slice(3, 7);
+
+  const data = locations.map((loc) => {
+    let itemId: number | null = null;
+    let rewardAmount = 0;
+
+    if (itemLocations.includes(loc)) {
+      itemId = getRandomInt(99000020, 99000030);
+    } else if (rewardLocations.includes(loc)) {
+      rewardAmount = getRandomInt(1, 4);
+    }
+
+    return {
+      playerId,
+      rewardType,
+      seq: loc,
+      locationId: loc,
+      itemId,
+      rewardAmount,
+    };
+  });
+
+  await prisma.playerAchievement.createMany({ data });
+
+  return prisma.playerAchievement.findMany({
+    where: { playerId, rewardType },
+    orderBy: { seq: 'asc' },
+    select: {
+      seq: true,
+      locationId: true,
+      itemId: true,
+      rewardAmount: true,
+    },
+  });
+};
+
+function getRandomInt(min: number, max: number) {
+  return Math.floor(Math.random() * (max - min + 1)) + min;
+}


### PR DESCRIPTION
## Summary
- add reward refresh service for daily rewards
- add controller endpoint to regenerate rewards

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a1aeacfadc83329fa3ed9ac3ae1a9c