### PR TITLE
Add reward refresh route

### DIFF
--- a/src/routes/rewardRoutes.ts
+++ b/src/routes/rewardRoutes.ts
@@ -1,8 +1,9 @@
 import { Router } from 'express';
-import * as RewardController from '../controllers/rewardController';
+import { getRewards, refreshRewards } from '../controllers/rewardController';
 
 const router = Router();
 
-router.get('/rewards', RewardController.getRewards);
+router.get('/rewards', getRewards);
+router.post('/rewards/refresh', refreshRewards);
 
 export default router;


### PR DESCRIPTION
## Summary
- import refreshRewards controller in reward routes
- expose POST /rewards/refresh endpoint

## Testing
- `npm test` (fails: Error: no test specified)
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a1afb2b7248332b9fad73c31cd1d8f