### PR TITLE
feat: enable reward claiming

### DIFF
--- a/src/controllers/rewardController.ts
+++ b/src/controllers/rewardController.ts
@@ -1,5 +1,9 @@
 import { Request, Response } from 'express';
-import { listRewards, refreshRewards as refreshRewardsService } from '../services/rewardService';
+import {
+  listRewards,
+  refreshRewards as refreshRewardsService,
+  claimReward as claimRewardService,
+} from '../services/rewardService';
 
 export const getRewards = async (req: Request, res: Response) => {
   try {
@@ -49,6 +53,38 @@ export const refreshRewards = async (req: Request, res: Response) => {
 
     const rewards = await refreshRewardsService(playerIdNum);
     res.json(rewards);
+  } catch (error: any) {
+    res.status(500).json({ message: error.message });
+  }
+};
+
+export const claimReward = async (req: Request, res: Response) => {
+  try {
+    const playerId = Number(req.body.playerId);
+    const locationId = Number(req.body.locationId);
+    const rewardType = req.body.rewardType;
+
+    if (
+      isNaN(playerId) ||
+      isNaN(locationId) ||
+      typeof rewardType !== 'string'
+    ) {
+      res.status(400).json({ message: 'Missing or invalid parameters' });
+      return;
+    }
+
+    const achievement = await claimRewardService(
+      playerId,
+      locationId,
+      rewardType,
+    );
+
+    if (!achievement) {
+      res.status(404).json({ message: 'No reward found' });
+      return;
+    }
+
+    res.json(achievement);
   } catch (error: any) {
     res.status(500).json({ message: error.message });
   }

--- a/src/routes/rewardRoutes.ts
+++ b/src/routes/rewardRoutes.ts
@@ -1,9 +1,14 @@
 import { Router } from 'express';
-import { getRewards, refreshRewards } from '../controllers/rewardController';
+import {
+  getRewards,
+  refreshRewards,
+  claimReward,
+} from '../controllers/rewardController';
 
 const router = Router();
 
 router.get('/rewards', getRewards);
 router.post('/rewards/refresh', refreshRewards);
+router.post('/rewards/claim', claimReward);
 
 export default router;

--- a/src/services/rewardService.ts
+++ b/src/services/rewardService.ts
@@ -1,4 +1,5 @@
 import prisma from '../models/prismaClient';
+import { addItemToInventory } from './playerItemService';
 
 export const listRewards = async (
   rewardType: string,
@@ -74,3 +75,47 @@ export const refreshRewards = async (playerId: number) => {
 function getRandomInt(min: number, max: number) {
   return Math.floor(Math.random() * (max - min + 1)) + min;
 }
+
+export const claimReward = async (
+  playerId: number,
+  locationId: number,
+  rewardType: string,
+) => {
+  const achievement = await prisma.$transaction(async (tx) => {
+    const found = await tx.playerAchievement.findFirst({
+      where: { playerId, rewardType, locationId },
+    });
+
+    if (!found || found.isUsed) {
+      return null;
+    }
+
+    const updated = await tx.playerAchievement.update({
+      where: {
+        playerId_rewardType_seq: {
+          playerId,
+          rewardType,
+          seq: found.seq,
+        },
+      },
+      data: { isUsed: true },
+    });
+
+    if ((found.rewardAmount ?? 0) > 0) {
+      await tx.player.update({
+        where: { id: playerId },
+        data: {
+          RingBall: { increment: found.rewardAmount ?? 0 },
+        },
+      });
+    }
+
+    return updated;
+  });
+
+  if (achievement && achievement.itemId) {
+    await addItemToInventory(playerId, achievement.itemId);
+  }
+
+  return achievement;
+};


### PR DESCRIPTION
## Summary
- implement reward claiming logic with transaction, inventory item grants, and RingBall updates
- expose reward claiming API endpoint and route with validation

## Testing
- `npm test` (fails: Error: no test specified)
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a1c5abec148332a7356508a087709c