### PR TITLE
feat: support inserting player achievements

### DIFF
--- a/src/controllers/rewardController.ts
+++ b/src/controllers/rewardController.ts
@@ -3,6 +3,7 @@ import {
   listRewards,
   refreshRewards as refreshRewardsService,
   claimReward as claimRewardService,
+  insertPlayerAchievement as insertPlayerAchievementService,
 } from '../services/rewardService';
 
 export const getRewards = async (req: Request, res: Response) => {
@@ -85,6 +86,28 @@ export const claimReward = async (req: Request, res: Response) => {
     }
 
     res.json(achievement);
+  } catch (error: any) {
+    res.status(500).json({ message: error.message });
+  }
+};
+
+export const insertPlayerAchievement = async (req: Request, res: Response) => {
+  try {
+    const { playerId, rewardType } = req.body;
+
+    const playerIdNum = Number(playerId);
+    if (isNaN(playerIdNum) || typeof rewardType !== 'string') {
+      res
+        .status(400)
+        .json({ message: 'Missing or invalid playerId or rewardType' });
+      return;
+    }
+
+    const achievements = await insertPlayerAchievementService(
+      playerIdNum,
+      rewardType,
+    );
+    res.json(achievements);
   } catch (error: any) {
     res.status(500).json({ message: error.message });
   }

--- a/src/routes/rewardRoutes.ts
+++ b/src/routes/rewardRoutes.ts
@@ -3,6 +3,7 @@ import {
   getRewards,
   refreshRewards,
   claimReward,
+  insertPlayerAchievement,
 } from '../controllers/rewardController';
 
 const router = Router();
@@ -10,5 +11,6 @@ const router = Router();
 router.get('/rewards', getRewards);
 router.post('/rewards/refresh', refreshRewards);
 router.post('/rewards/claim', claimReward);
+router.post('/rewards/insert', insertPlayerAchievement);
 
 export default router;

--- a/src/services/rewardService.ts
+++ b/src/services/rewardService.ts
@@ -26,9 +26,50 @@ export const listRewards = async (
   return achievements;
 };
 
-export const refreshRewards = async (playerId: number) => {
-  const rewardType = '11100001';
+export const insertPlayerAchievement = async (
+  playerId: number,
+  rewardType: string,
+) => {
+  if (rewardType === '11100001') {
+    const startOfDay = new Date();
+    startOfDay.setHours(0, 0, 0, 0);
+    const endOfDay = new Date();
+    endOfDay.setHours(23, 59, 59, 999);
 
+    const existing = await prisma.playerAchievement.findFirst({
+      where: {
+        playerId,
+        rewardType,
+        achievedAt: {
+          gte: startOfDay,
+          lte: endOfDay,
+        },
+      },
+    });
+
+    if (existing) {
+      return prisma.playerAchievement.findMany({
+        where: { playerId, rewardType },
+        orderBy: { seq: 'asc' },
+        select: {
+          seq: true,
+          locationId: true,
+          itemId: true,
+          rewardAmount: true,
+        },
+      });
+    }
+
+    return refreshRewards(playerId, rewardType);
+  }
+
+  return [];
+};
+
+export const refreshRewards = async (
+  playerId: number,
+  rewardType = '11100001',
+) => {
   await prisma.playerAchievement.deleteMany({
     where: { playerId, rewardType },
   });


### PR DESCRIPTION
## Summary
- allow inserting player achievements with daily check
- expose controller and route for inserting player achievement
- parameterize reward refresh to accept reward type

## Testing
- `npm run build`
- `npm test` (fails: Error: no test specified)


------
https://chatgpt.com/codex/tasks/task_e_68a1dd3c44d48332af5fa025f21ce009