### PR TITLE
feat: support materials in item level up

### DIFF
--- a/ReadMe
+++ b/ReadMe
@@ -22,6 +22,17 @@ GET /api/players/:id/inventory - Túi đồ người chơi
 POST /api/players/ball-physics - Chỉ số vật lý viên bi đang trang bị (danh sách id)
 POST /api/player/equip - Trang bị vật phẩm cho người chơi
 POST /api/effect-player/item-level-up - Nâng cấp level của vật phẩm
+Body JSON /effect-player/item-level-up:
+{
+  "playerId": 1,
+  "itemId": 5,
+  "seq": 0,
+  "materials": [
+    { "id": 10, "seq": 0 },
+    { "id": 11, "seq": 1 }
+  ]
+}
+
 GET /api/histories?page=1&pageSize=10 - Lịch sử trận đấu (mặc định 10 bản ghi gần nhất, hỗ trợ phân trang)
 POST /api/draw-reward - Bốc thăm trúng thưởng (body: {"playerId": number})
 POST /api/friend-request - Gửi lời mời kết bạn (body: {"senderId": number, "friendCode": string})

--- a/src/controllers/effectPlayerController.ts
+++ b/src/controllers/effectPlayerController.ts
@@ -44,13 +44,17 @@ export const levelUpItem = async (req: Request, res: Response) => {
     const playerId = Number(req.body.playerId);
     const itemId = Number(req.body.itemId);
     const seq = Number(req.body.seq);
+    const rawMaterials = Array.isArray(req.body.materials) ? req.body.materials : [];
+    const materials = rawMaterials
+      .map((m: any) => ({ id: Number(m.id), seq: Number(m.seq) }))
+      .filter((m) => !isNaN(m.id) && !isNaN(m.seq));
 
     if (isNaN(playerId) || isNaN(itemId) || isNaN(seq)) {
       res.status(400).json({ message: 'Invalid parameters' });
       return;
     }
 
-    const updated = await levelUpPlayerItem(playerId, itemId, seq);
+    const updated = await levelUpPlayerItem(playerId, itemId, seq, materials);
     res.json(updated);
   } catch (error: any) {
     res.status(500).json({ message: error.message });

--- a/src/services/playerItemService.ts
+++ b/src/services/playerItemService.ts
@@ -163,37 +163,53 @@ export const sellItem = async (
   });
 };
 
+type Material = { id: number; seq: number };
+
 export const levelUpPlayerItem = async (
   playerId: number,
   itemId: number,
-  seq: number
+  seq: number,
+  materials: Material[] = []
 ) => {
-  const playerItem = await prisma.playerItem.findUnique({
-    where: {
-      playerId_itemId_seq: {
-        playerId,
-        itemId,
-        seq,
+  return prisma.$transaction(async (tx) => {
+    const playerItem = await tx.playerItem.findUnique({
+      where: {
+        playerId_itemId_seq: {
+          playerId,
+          itemId,
+          seq,
+        },
       },
-    },
-    select: { playerId: true },
-  });
+      select: { playerId: true },
+    });
 
-  if (!playerItem) {
-    throw new Error('PlayerItem not found');
-  }
+    if (!playerItem) {
+      throw new Error('PlayerItem not found');
+    }
 
-  return prisma.playerItem.update({
-    where: {
-      playerId_itemId_seq: {
-        playerId,
-        itemId,
-        seq,
+    const updated = await tx.playerItem.update({
+      where: {
+        playerId_itemId_seq: {
+          playerId,
+          itemId,
+          seq,
+        },
       },
-    },
-    data: {
-      level: { increment: 1 },
-    },
+      data: {
+        level: { increment: 1 },
+      },
+    });
+
+    if (materials.length > 0) {
+      await tx.playerItem.deleteMany({
+        where: {
+          playerId,
+          OR: materials.map((m) => ({ itemId: m.id, seq: m.seq })),
+        },
+      });
+    }
+
+    return updated;
   });
 };
 


### PR DESCRIPTION
## Summary
- add `materials` list to item level-up API
- remove sacrificed items from inventory during level up
- document request body for `/effect-player/item-level-up`

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run build` *(fails: Cannot find module 'express' or its corresponding type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_68a2da1be4588332a6cf34bdf6fab60c