### PR TITLE
Add PlayerAchievementStatus Prisma model

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -30,6 +30,7 @@ model Player {
   histories              History[]
   effectPlayers          EffectPlayer[]
   playerAchievements     PlayerAchievement[]
+  achievementStatuses    PlayerAchievementStatus[]
   dailyRareItem          DailyRareItem[]
   equipPlayers           EquipPlayer[]
   sentFriendRequests     FriendRequest[]     @relation("SentFriendRequests")
@@ -82,6 +83,7 @@ model Item {
   ImpactResistance Float?
   playerItems      PlayerItem[]
   equipPlayers     EquipPlayer[]
+  achievementStatuses PlayerAchievementStatus[]
 }
 
 model PlayerItem {
@@ -163,9 +165,21 @@ model PlayerAchievement {
   achievedAt    DateTime @default(now())
 
   player      Player      @relation(fields: [playerId], references: [id])
- 
+
 
   @@id([playerId,rewardType, seq])
+}
+
+model PlayerAchievementStatus {
+  playerId     Int
+  typeGid      Int
+  achievementId Int
+  itemId       Int
+
+  player Player @relation(fields: [playerId], references: [id])
+  item   Item   @relation(fields: [itemId], references: [id])
+
+  @@id([playerId, typeGid, achievementId])
 }
 
 model DailyRareItem {


### PR DESCRIPTION
## Summary
- add `PlayerAchievementStatus` model with composite primary key and relations
- link `Player` and `Item` to new achievement status entries

## Testing
- `DATABASE_URL="postgresql://user:pass@localhost:5432/db" npx prisma migrate dev --name player-achievement-status` *(fails: Can't reach database server at `localhost:5432`)*
- `DATABASE_URL="postgresql://user:pass@localhost:5432/db" npx prisma generate`


------
https://chatgpt.com/codex/tasks/task_e_68a418f64b588332af50cf7a3397e9d5