### PR TITLE
feat: add player achievement listing

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -13,6 +13,7 @@ import marketRoutes from './routes/marketRoutes';
 import accountRoutes from './routes/accountRoutes';
 import friendRoutes from './routes/friendRoutes';
 import rewardRoutes from './routes/rewardRoutes';
+import achievementRoutes from './routes/achievementRoutes';
 
 const app = express();
 
@@ -34,6 +35,7 @@ app.use('/api', marketRoutes);
 app.use('/api', accountRoutes);
 app.use('/api', friendRoutes);
 app.use('/api', rewardRoutes);
+app.use('/api', achievementRoutes);
 
 // KHÔNG CÒN BẤT KỲ ĐOẠN app.listen() hay new WebSocket.Server() nào ở đây
 

--- a/src/controllers/achievementController.ts
+++ b/src/controllers/achievementController.ts
@@ -1,0 +1,12 @@
+import { Request, Response } from 'express';
+import { listPlayerAchievements } from '../services/achievementService';
+
+export const getPlayerAchievements = async (req: Request, res: Response) => {
+  try {
+    const playerId = Number(req.query.playerId);
+    const achievements = await listPlayerAchievements(playerId);
+    res.json(achievements);
+  } catch (error: any) {
+    res.status(500).json({ message: error.message });
+  }
+};

--- a/src/routes/achievementRoutes.ts
+++ b/src/routes/achievementRoutes.ts
@@ -1,0 +1,8 @@
+import { Router } from 'express';
+import * as AchievementController from '../controllers/achievementController';
+
+const router = Router();
+
+router.get('/achievements', AchievementController.getPlayerAchievements);
+
+export default router;

--- a/src/services/achievementService.ts
+++ b/src/services/achievementService.ts
@@ -1,0 +1,7 @@
+import prisma from '../models/prismaClient';
+
+export const listPlayerAchievements = async (playerId: number) => {
+  return prisma.playerAchievementStatus.findMany({
+    where: { playerId },
+  });
+};


### PR DESCRIPTION
## Summary
- add service to fetch player achievement status
- expose controller and route for `/achievements`
- wire achievement routes into express app

## Testing
- `npm test` (fails: Error: no test specified)
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a41aa026a08332bec66cd29491d36a