### PR TITLE
feat: allow claiming achievement rewards

### DIFF
--- a/src/controllers/achievementController.ts
+++ b/src/controllers/achievementController.ts
@@ -1,11 +1,42 @@
 import { Request, Response } from 'express';
-import { listPlayerAchievements } from '../services/achievementService';
+import {
+  listPlayerAchievements,
+  claimAchievement,
+} from '../services/achievementService';
 
 export const getPlayerAchievements = async (req: Request, res: Response) => {
   try {
     const playerId = Number(req.query.playerId);
     const achievements = await listPlayerAchievements(playerId);
     res.json(achievements);
+  } catch (error: any) {
+    res.status(500).json({ message: error.message });
+  }
+};
+
+export const claimAchievementReward = async (req: Request, res: Response) => {
+  try {
+    const { playerId, typeGid, achievementId } = req.body || {};
+
+    if (
+      typeof playerId !== 'number' ||
+      typeof typeGid !== 'number' ||
+      typeof achievementId !== 'number'
+    ) {
+      res
+        .status(400)
+        .json({ message: 'playerId, typeGid, achievementId are required' });
+      return;
+    }
+
+    const result = await claimAchievement(playerId, typeGid, achievementId);
+
+    if (!result) {
+      res.status(404).json({ message: 'Achievement not found or already claimed' });
+      return;
+    }
+
+    res.json(result);
   } catch (error: any) {
     res.status(500).json({ message: error.message });
   }

--- a/src/routes/achievementRoutes.ts
+++ b/src/routes/achievementRoutes.ts
@@ -4,5 +4,6 @@ import * as AchievementController from '../controllers/achievementController';
 const router = Router();
 
 router.get('/achievements', AchievementController.getPlayerAchievements);
+router.post('/achievements/claim', AchievementController.claimAchievementReward);
 
 export default router;

--- a/src/services/achievementService.ts
+++ b/src/services/achievementService.ts
@@ -1,7 +1,48 @@
 import prisma from '../models/prismaClient';
+import { addItemToInventory } from './playerItemService';
 
 export const listPlayerAchievements = async (playerId: number) => {
   return prisma.playerAchievementStatus.findMany({
     where: { playerId },
   });
+};
+
+export const claimAchievement = async (
+  playerId: number,
+  typeGid: number,
+  achievementId: number,
+) => {
+  const result = await prisma.$transaction(async (tx) => {
+    const record: any = await tx.playerAchievementStatus.findUnique({
+      where: {
+        playerId_typeGid_achievementId: { playerId, typeGid, achievementId },
+      },
+    });
+
+    if (!record || !record.isComplete || record.isGiftReceived) {
+      return null;
+    }
+
+    await (tx.playerAchievementStatus as any).update({
+      where: {
+        playerId_typeGid_achievementId: { playerId, typeGid, achievementId },
+      },
+      data: { isGiftReceived: true },
+    });
+
+    if ((record.ringBall ?? 0) > 0) {
+      await tx.player.update({
+        where: { id: playerId },
+        data: { RingBall: { increment: record.ringBall } },
+      });
+    }
+
+    return record;
+  });
+
+  if (result && (result as any).itemId) {
+    await addItemToInventory(playerId, (result as any).itemId);
+  }
+
+  return result;
 };


### PR DESCRIPTION
## Summary
- add service to claim achievement rewards and grant items or RingBall
- expose controller and route to claim achievement reward

## Testing
- `npm run build`
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68a41bd68ec08332a7237da12b9d46b6