### PR TITLE
feat: add read friend message endpoint

### DIFF
--- a/src/controllers/friendController.ts
+++ b/src/controllers/friendController.ts
@@ -4,6 +4,7 @@ import {
   removeFriend,
   respondFriendRequest,
   sendMessage,
+  readMessage,
   deleteFriendMessage,
   receiveItems,
   getFriendList,
@@ -172,6 +173,47 @@ export const getFriendMessagesController = async (
     const result = await getFriendMessages(receiverId);
     if (result.success) {
       res.json(result.data);
+      return;
+    }
+    res.status(400).json({ message: result.message });
+  } catch (error: any) {
+    res.status(500).json({ message: error.message });
+  }
+};
+
+export const readFriendMessageController = async (
+  req: Request,
+  res: Response
+): Promise<void> => {
+  try {
+    const playerId = Number(req.body.playerId ?? req.params.playerId);
+    const seqMess = Number(req.body.seqMess ?? req.params.seqMess);
+    const receiverIdRaw = req.body.receiverId ?? req.params.receiverId;
+    const receiverId =
+      receiverIdRaw !== undefined ? Number(receiverIdRaw) : undefined;
+
+    if (
+      isNaN(playerId) ||
+      isNaN(seqMess) ||
+      (receiverIdRaw !== undefined && isNaN(receiverId))
+    ) {
+      res.status(400).json({ message: 'Invalid parameters' });
+      return;
+    }
+
+    // Optional validation: ensure requester is the intended receiver
+    if (
+      receiverId !== undefined &&
+      Number(req.body.requesterId ?? req.params.requesterId ?? receiverId) !==
+        receiverId
+    ) {
+      res.status(403).json({ message: 'Forbidden' });
+      return;
+    }
+
+    const result = await readMessage(playerId, seqMess, receiverId);
+    if (result.success) {
+      res.json({ success: true });
       return;
     }
     res.status(400).json({ message: result.message });

--- a/src/routes/friendRoutes.ts
+++ b/src/routes/friendRoutes.ts
@@ -5,6 +5,7 @@ import {
   removeFriendController,
   respondFriendRequestController,
   sendMessageController,
+  readFriendMessageController,
   receiveItemsController,
   getFriendListController,
   getPendingFriendRequestsController,
@@ -19,6 +20,7 @@ router.post('/friend-request', sendFriendRequestController);
 router.post('/friend-remove', removeFriendController);
 router.post('/friend-respond', respondFriendRequestController);
 router.post('/send-message', sendMessageController);
+router.post('/read-message', readFriendMessageController);
 router.post('/receive-items', receiveItemsController);
 router.get('/friend-search/:id', searchPlayerByIdController);
 router.get('/friend-list/:playerId', getFriendListController);

--- a/src/services/friendService.ts
+++ b/src/services/friendService.ts
@@ -212,6 +212,26 @@ export const sendMessage = async (
   }
 };
 
+export const readMessage = async (
+  playerId: number,
+  seqMess: number,
+  receiverId?: number
+) => {
+  try {
+    await prisma.friendMessage.updateMany({
+      where: {
+        senderId: playerId,
+        seqMess,
+        ...(receiverId !== undefined ? { receiverId } : {}),
+      },
+      data: { status: 'READ' },
+    });
+    return { success: true };
+  } catch (error: any) {
+    return { success: false, message: error.message };
+  }
+};
+
 export const receiveItems = async (
   senderId: number,
   receiverId: number,


### PR DESCRIPTION
## Summary
- add service to mark friend messages as read
- expose controller and route for `/read-message`

## Testing
- `npm test` (fails: Error: no test specified)
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a52153df60833294142e06552cf1ce