### PR TITLE
feat: surface seller name on market items

### DIFF
--- a/src/controllers/marketController.ts
+++ b/src/controllers/marketController.ts
@@ -3,7 +3,8 @@ import {
   listItemForSale,
   buyMarketItem,
   cancelSale,
-  getListedItems as getListedItemsService
+  getListedItems as getListedItemsService,
+  ListedItemResult
 } from '../services/marketService';
 
 export const sellOnMarket = async (req: Request, res: Response) => {
@@ -79,9 +80,15 @@ export const getListedItems = async (req: Request, res: Response) => {
       priceOrder,
       levelOrder,
       skip,
-      take: pageSize
+      take: pageSize,
     });
-    res.json(items);
+    const response: (ListedItemResult & { playerName: string | null })[] = items.map(
+      (i) => ({
+        ...i,
+        playerName: i.player?.PlayerName ?? null,
+      })
+    );
+    res.json(response);
   } catch (error: any) {
     res.status(500).json({ message: error.message });
   }

--- a/src/services/marketService.ts
+++ b/src/services/marketService.ts
@@ -1,4 +1,5 @@
 import prisma from '../models/prismaClient';
+import { Prisma } from '@prisma/client';
 
 export const listItemForSale = async (
   playerId: number,
@@ -150,6 +151,13 @@ export interface ListedItemFilters {
   take?: number;
 }
 
+export type ListedItemResult = Prisma.PlayerItemGetPayload<{
+  include: {
+    item: true;
+    player: { select: { PlayerName: true } };
+  };
+}>;
+
 export const getListedItems = async ({
   itemName,
   level,
@@ -157,7 +165,7 @@ export const getListedItems = async ({
   levelOrder,
   skip = 0,
   take = 10
-}: ListedItemFilters) => {
+}: ListedItemFilters): Promise<ListedItemResult[]> => {
   const where: any = { IsSolded: 1 };
 
   if (level !== undefined && !isNaN(level)) {
@@ -178,9 +186,12 @@ export const getListedItems = async ({
 
   return prisma.playerItem.findMany({
     where,
-    include: { item: true },
+    include: {
+      item: true,
+      player: { select: { PlayerName: true } },
+    },
     orderBy: orderBy.length > 0 ? orderBy : undefined,
     skip,
-    take
+    take,
   });
 };


### PR DESCRIPTION
## Summary
- include seller's PlayerName in market listing query
- expose playerName on controller response
- add typed result for listing lookups

## Testing
- `npm test` (fails: Error: no test specified)
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bafa71d59c83328cd45676e711f22c