### PR TITLE
Align PlayerAchievementStatus relation

### DIFF
--- a/prisma/migrations/20250219000000_player-achievement-status-rel/migration.sql
+++ b/prisma/migrations/20250219000000_player-achievement-status-rel/migration.sql
@@ -1,0 +1,8 @@
+-- AlterTable
+ALTER TABLE "PlayerAchievementStatus" DROP CONSTRAINT "PlayerAchievementStatus_pkey",
+ALTER COLUMN "typeGid" SET DATA TYPE TEXT,
+ADD CONSTRAINT "PlayerAchievementStatus_pkey" PRIMARY KEY ("playerId", "typeGid", "achievementId");
+
+-- AddForeignKey
+ALTER TABLE "PlayerAchievementStatus" ADD CONSTRAINT "PlayerAchievementStatus_typeGid_achievementId_fkey" FOREIGN KEY ("typeGid", "achievementId") REFERENCES "PlayerAchievement"("rewardType", "seq") ON DELETE RESTRICT ON UPDATE CASCADE;
+

--- a/prisma/migrations/migration_lock.toml
+++ b/prisma/migrations/migration_lock.toml
@@ -1,0 +1,1 @@
+provider = "postgresql"

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -14,8 +14,8 @@ datasource db {
 }
 
 model Player {
-  id                     Int                 @id @default(autoincrement())
-  friendCode             String  @unique                       // mã công khai để tìm
+  id                     Int                       @id @default(autoincrement())
+  friendCode             String                    @unique // mã công khai để tìm
   PlayerName             String?
   Level                  Int?
   Exp                    Int?
@@ -33,12 +33,12 @@ model Player {
   achievementStatuses    PlayerAchievementStatus[]
   dailyRareItem          DailyRareItem[]
   equipPlayers           EquipPlayer[]
-  sentFriendRequests     FriendRequest[]     @relation("SentFriendRequests")
-  receivedFriendRequests FriendRequest[]     @relation("ReceivedFriendRequests")
-  friendships            Friendship[]        @relation("PlayerFriendships")
-  friends                Friendship[]        @relation("FriendPlayerShips")
-  messagesSent           FriendMessage[]     @relation("MessagesSent")
-  messagesReceived       FriendMessage[]     @relation("MessagesReceived")
+  sentFriendRequests     FriendRequest[]           @relation("SentFriendRequests")
+  receivedFriendRequests FriendRequest[]           @relation("ReceivedFriendRequests")
+  friendships            Friendship[]              @relation("PlayerFriendships")
+  friends                Friendship[]              @relation("FriendPlayerShips")
+  messagesSent           FriendMessage[]           @relation("MessagesSent")
+  messagesReceived       FriendMessage[]           @relation("MessagesReceived")
 }
 
 // SYSTEM
@@ -64,26 +64,26 @@ model RoomUser {
 }
 
 model Item {
-  id               Int           @id
-  name             String
-  ElementType      Int?           //Loại nguyên tố của vật phẩm
-  description      String
-  level            Int
-  typeGid          Int           @map("Type_Gid")
-  price            Int
-  priceByBall      Int?
-  isLevelUp        Boolean       @map("is_Level_Up")
-  isOpen           Boolean
-  locationGid      Int           @map("Location_Gid")
-  Levelrequired    Int?
-  Mass             Float?
-  GravityScale     Float?
-  Drag             Float?
-  Bounciness       Float?
-  Elasticity       Float?
-  ImpactResistance Float?
-  playerItems      PlayerItem[]
-  equipPlayers     EquipPlayer[]
+  id                  Int                       @id
+  name                String
+  ElementType         Int? //Loại nguyên tố của vật phẩm
+  description         String
+  level               Int
+  typeGid             Int                       @map("Type_Gid")
+  price               Int
+  priceByBall         Int?
+  isLevelUp           Boolean                   @map("is_Level_Up")
+  isOpen              Boolean
+  locationGid         Int                       @map("Location_Gid")
+  Levelrequired       Int?
+  Mass                Float?
+  GravityScale        Float?
+  Drag                Float?
+  Bounciness          Float?
+  Elasticity          Float?
+  ImpactResistance    Float?
+  playerItems         PlayerItem[]
+  equipPlayers        EquipPlayer[]
   achievementStatuses PlayerAchievementStatus[]
 }
 
@@ -154,7 +154,6 @@ model EffectPlayer {
   @@id([playerId, effectId])
 }
 
-
 model PlayerAchievement {
   playerId     Int?
   seq          Int
@@ -162,24 +161,26 @@ model PlayerAchievement {
   locationId   Int?
   rewardAmount Int?
   itemId       Int?
-  isUsed       Boolean @default(false)
-  achievedAt    DateTime @default(now())
+  isUsed       Boolean  @default(false)
+  achievedAt   DateTime @default(now())
 
- player      Player?     @relation(fields: [playerId], references: [id])
+  player   Player?                   @relation(fields: [playerId], references: [id])
+  statuses PlayerAchievementStatus[] @relation("PlayerAchievementToStatus")
 
   @@id([rewardType, seq])
 }
 
 model PlayerAchievementStatus {
-  playerId     Int
-  typeGid      Int
-  achievementId Int
-  itemId       Int
-  isComplete Boolean @default(false)
-  isGiftReceived Boolean @default(false)
-  updatedAt    DateTime @default(now())
-  player Player @relation(fields: [playerId], references: [id])
-  item   Item   @relation(fields: [itemId], references: [id])
+  playerId       Int
+  typeGid        String
+  achievementId  Int
+  itemId         Int
+  isComplete     Boolean           @default(false)
+  isGiftReceived Boolean           @default(false)
+  updatedAt      DateTime          @default(now())
+  player         Player            @relation(fields: [playerId], references: [id])
+  item           Item              @relation(fields: [itemId], references: [id])
+  achievement    PlayerAchievement @relation("PlayerAchievementToStatus", fields: [typeGid, achievementId], references: [rewardType, seq])
 
   @@id([playerId, typeGid, achievementId])
 }
@@ -244,12 +245,13 @@ model FriendMessage {
   senderId   Int
   seqMess    Int
   receiverId Int
-  status     String @default("PENDING") // PENDING, READ
+  status     String   @default("PENDING") // PENDING, READ
   message    String
   itemId     Int?
   seqId      Int?
   createdAt  DateTime @default(now())
+  sender     Player   @relation("MessagesSent", fields: [senderId], references: [id])
+  receiver   Player   @relation("MessagesReceived", fields: [receiverId], references: [id])
+
   @@id([senderId, seqMess])
-  sender   Player @relation("MessagesSent", fields: [senderId], references: [id])
-  receiver Player @relation("MessagesReceived", fields: [receiverId], references: [id])
 }


### PR DESCRIPTION
## Summary
- align PlayerAchievementStatus.typeGid with PlayerAchievement.rewardType by switching the field to String
- add explicit relation fields between PlayerAchievement and PlayerAchievementStatus
- add a Prisma migration covering the schema updates

## Testing
- `npx prisma format`
- `npx prisma generate`


------
https://chatgpt.com/codex/tasks/task_e_68c8f0686f3c8332aa37c400fb98ade2