### PR TITLE
Refactor reward handling to use PlayerAchievementStatus

### DIFF
--- a/src/controllers/rewardController.ts
+++ b/src/controllers/rewardController.ts
@@ -52,7 +52,16 @@ export const refreshRewards = async (req: Request, res: Response) => {
       return;
     }
 
-    const rewards = await refreshRewardsService(playerIdNum);
+    const rewardTypeParam = (req.query.rewardType ?? req.body.rewardType) as
+      | string
+      | undefined;
+    const rewardTypeValue =
+      typeof rewardTypeParam === 'string' ? rewardTypeParam : undefined;
+
+    const rewards = await refreshRewardsService(
+      playerIdNum,
+      rewardTypeValue,
+    );
     res.json(rewards);
   } catch (error: any) {
     res.status(500).json({ message: error.message });

--- a/src/services/rewardService.ts
+++ b/src/services/rewardService.ts
@@ -1,30 +1,110 @@
 import prisma from '../models/prismaClient';
 import { addItemToInventory } from './playerItemService';
 
+const MAX_REWARD_LOCATIONS = 20;
+
+type RewardRecord = {
+  seq: number;
+  locationId: number | null;
+  itemId: number | null;
+  rewardAmount: number;
+  isUsed: boolean;
+};
+
+const buildRewardRecord = (
+  status: any | undefined,
+  achievement?: any,
+): RewardRecord => {
+  const relatedAchievement = achievement ?? status?.achievement ?? {};
+  const seq =
+    status?.seq ??
+    status?.achievementId ??
+    relatedAchievement?.seq ??
+    relatedAchievement?.achievementId ??
+    0;
+
+  const locationId =
+    status?.locationId ??
+    relatedAchievement?.locationId ??
+    (typeof seq === 'number' && seq > 0 ? seq : null);
+
+  const itemId =
+    status?.itemId ??
+    relatedAchievement?.itemId ??
+    null;
+
+  const rewardAmount =
+    status?.rewardAmount ??
+    relatedAchievement?.rewardAmount ??
+    0;
+
+  const isUsed = Boolean(
+    status?.isUsed ??
+      status?.isComplete ??
+      status?.isGiftReceived ??
+      relatedAchievement?.isUsed ??
+      false,
+  );
+
+  return {
+    seq,
+    locationId,
+    itemId,
+    rewardAmount,
+    isUsed,
+  };
+};
+
+const ensureBaseAchievements = async (
+  rewardType: string,
+  tx: any,
+) => {
+  const sequences = Array.from({ length: MAX_REWARD_LOCATIONS }, (_, index) => index + 1);
+
+  const existing = await (tx.playerAchievement as any).findMany({
+    where: { rewardType, seq: { in: sequences } },
+    select: { seq: true },
+  });
+
+  const existingSeqs = new Set(existing.map((entry) => entry.seq));
+  const toCreate = sequences
+    .filter((seq) => !existingSeqs.has(seq))
+    .map((seq) => ({
+      rewardType,
+      seq,
+      locationId: seq,
+      rewardAmount: 0,
+      itemId: null,
+      isUsed: false,
+    }));
+
+  if (toCreate.length > 0) {
+    await (tx.playerAchievement as any).createMany({ data: toCreate });
+  }
+};
+
 export const listRewards = async (
   rewardType: string,
   playerId: number,
   dayOfWeek?: number,
 ) => {
-  const achievements = await prisma.playerAchievement.findMany({
-    where: {
-      rewardType,
-      playerId,
-    },
-    orderBy: {
-      seq: 'asc',
-    },
-    take: 20,
-    select: {
-      //seq: true,
-      locationId: true,
-      //itemId: true,
-      //rewardAmount: true,
-      isUsed: true,
+  await ensureBaseAchievements(rewardType, prisma);
+
+  const achievements = await (prisma.playerAchievement as any).findMany({
+    where: { rewardType },
+    orderBy: { seq: 'asc' },
+    take: MAX_REWARD_LOCATIONS,
+    include: {
+      statuses: {
+        where: { playerId, rewardType },
+        take: 1,
+      },
     },
   });
 
-  return achievements;
+  return achievements.map((achievement) =>
+    buildRewardRecord((achievement as any).statuses?.[0], achievement),
+  );
 };
 
 export const insertPlayerAchievement = async (
@@ -37,28 +117,19 @@ export const insertPlayerAchievement = async (
     const endOfDay = new Date();
     endOfDay.setHours(23, 59, 59, 999);
 
-    const existing = await prisma.playerAchievement.findFirst({
+    const existingStatus = await (prisma.playerAchievementStatus as any).findFirst({
       where: {
         playerId,
         rewardType,
-        achievedAt: {
+        updatedAt: {
           gte: startOfDay,
           lte: endOfDay,
         },
       },
     });
 
-    if (existing) {
-      return prisma.playerAchievement.findMany({
-        where: { playerId, rewardType },
-        orderBy: { seq: 'asc' },
-        select: {
-          seq: true,
-          locationId: true,
-          itemId: true,
-          rewardAmount: true,
-        },
-      });
+    if (existingStatus) {
+      return listRewards(rewardType, playerId);
     }
 
     return refreshRewards(playerId, rewardType);
@@ -71,47 +142,64 @@ export const refreshRewards = async (
   playerId: number,
   rewardType = '11100001',
 ) => {
-  await prisma.playerAchievement.deleteMany({
-    where: { playerId, rewardType },
+  const results = await prisma.$transaction(async (tx) => {
+    await ensureBaseAchievements(rewardType, tx);
+
+    await (tx.playerAchievementStatus as any).deleteMany({
+      where: { playerId, rewardType },
+    });
+
+    const locations = Array.from({ length: MAX_REWARD_LOCATIONS }, (_, index) => index + 1);
+    const shuffled = [...locations].sort(() => Math.random() - 0.5);
+    const itemLocations = shuffled.slice(0, 3);
+    const rewardLocations = shuffled.slice(3, 7);
+
+    const generatedAt = new Date();
+
+    const data = locations.map((loc) => {
+      let itemId: number | null = null;
+      let rewardAmount = 0;
+
+      if (itemLocations.includes(loc)) {
+        itemId = getRandomInt(99000002, 99000010);
+      } else if (rewardLocations.includes(loc)) {
+        rewardAmount = getRandomInt(1, 4);
+      }
+
+      return {
+        playerId,
+        rewardType,
+        seq: loc,
+        locationId: loc,
+        itemId,
+        rewardAmount,
+        isUsed: false,
+        updatedAt: generatedAt,
+      };
+    });
+
+    await (tx.playerAchievementStatus as any).createMany({ data });
+
+    const statuses = await (tx.playerAchievementStatus as any).findMany({
+      where: { playerId, rewardType },
+      orderBy: { seq: 'asc' },
+      include: {
+        achievement: {
+          select: {
+            seq: true,
+            locationId: true,
+            itemId: true,
+            rewardAmount: true,
+            isUsed: true,
+          },
+        },
+      },
+    });
+
+    return statuses.map((status: any) => buildRewardRecord(status, status.achievement));
   });
 
-  const locations = Array.from({ length: 20 }, (_, i) => i + 1);
-  const shuffled = [...locations].sort(() => Math.random() - 0.5);
-  const itemLocations = shuffled.slice(0, 3);
-  const rewardLocations = shuffled.slice(3, 7);
-
-  const data = locations.map((loc) => {
-    let itemId: number | null = null;
-    let rewardAmount = 0;
-
-    if (itemLocations.includes(loc)) {
-      itemId = getRandomInt(99000002, 99000010);
-    } else if (rewardLocations.includes(loc)) {
-      rewardAmount = getRandomInt(1, 4);
-    }
-
-    return {
-      playerId,
-      rewardType,
-      seq: loc,
-      locationId: loc,
-      itemId,
-      rewardAmount,
-    };
-  });
-
-  await prisma.playerAchievement.createMany({ data });
-
-  return prisma.playerAchievement.findMany({
-    where: { playerId, rewardType },
-    orderBy: { seq: 'asc' },
-    select: {
-      seq: true,
-      locationId: true,
-      itemId: true,
-      rewardAmount: true,
-    },
-  });
+  return results;
 };
 
 function getRandomInt(min: number, max: number) {
@@ -124,39 +212,51 @@ export const claimReward = async (
   rewardType: string,
 ) => {
   const achievement = await prisma.$transaction(async (tx) => {
-    const found = await tx.playerAchievement.findFirst({
-      where: { playerId, rewardType, locationId },
+    const status = await (tx.playerAchievementStatus as any).findFirst({
+      where: {
+        playerId,
+        rewardType,
+        seq: locationId,
+      },
+      include: {
+        achievement: true,
+      },
     });
 
-    if (!found || found.isUsed) {
+    if (!status || status.isUsed) {
       return null;
     }
 
-    const updated = await tx.playerAchievement.update({
+    await (tx.playerAchievementStatus as any).updateMany({
       where: {
-        playerId_rewardType_seq: {
-          playerId,
-          rewardType,
-          seq: found.seq,
-        },
+        playerId,
+        rewardType,
+        seq: locationId,
       },
-      data: { isUsed: true },
+      data: { isUsed: true, updatedAt: new Date() },
     });
 
-    if ((found.rewardAmount ?? 0) > 0) {
+    const rewardAmount =
+      status.rewardAmount ?? status.achievement?.rewardAmount ?? 0;
+
+    if (rewardAmount > 0) {
       await tx.player.update({
         where: { id: playerId },
-        data: {
-          RingBall: { increment: found.rewardAmount ?? 0 },
-        },
+        data: { RingBall: { increment: rewardAmount } },
       });
     }
 
-    return updated;
+    return { ...status, isUsed: true };
   });
 
-  if (achievement && achievement.itemId) {
-    await addItemToInventory(playerId, achievement.itemId);
+  if (achievement) {
+    const itemId = achievement.itemId ?? achievement.achievement?.itemId;
+
+    if (itemId) {
+      await addItemToInventory(playerId, itemId);
+    }
+
+    return buildRewardRecord(achievement, achievement.achievement);
   }
 
   return achievement;


### PR DESCRIPTION
## Summary
- ensure reward layouts are seeded per reward type and expose helpers to normalize reward records
- move reward refreshing, listing, and claiming logic to create and update PlayerAchievementStatus rows instead of player-specific PlayerAchievement rows
- allow the refresh controller to accept an optional rewardType parameter when invoking the refactored service

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68c9001e519c8332bc19811d58e374c9