### PR TITLE
Normalize achievement rewards from linked records

### DIFF
--- a/src/services/achievementService.ts
+++ b/src/services/achievementService.ts
@@ -1,9 +1,99 @@
 import prisma from '../models/prismaClient';
 import { addItemToInventory } from './playerItemService';
 
+type NormalizeOptions = {
+  achievement?: any;
+};
+
+const toFiniteNumber = (value: unknown) =>
+  typeof value === 'number' && Number.isFinite(value) ? value : undefined;
+
+const buildAchievementKey = (rewardType: unknown, seq: unknown) => {
+  const normalizedSeq = Number(seq);
+  const keySeq = Number.isFinite(normalizedSeq) ? normalizedSeq : '';
+
+  return `${String(rewardType ?? '')}:${keySeq}`;
+};
+
+const normalizeAchievementStatus = (
+  status: any,
+  { achievement }: NormalizeOptions = {},
+) => {
+  if (!status) {
+    return status;
+  }
+
+  const normalized = {
+    ...status,
+    itemId:
+      toFiniteNumber(status.itemId) ??
+      toFiniteNumber(achievement?.itemId) ??
+      null,
+    ringBall:
+      toFiniteNumber(status.ringBall) ??
+      toFiniteNumber(achievement?.ringBall) ??
+      toFiniteNumber(status.rewardAmount) ??
+      toFiniteNumber(achievement?.rewardAmount) ??
+      0,
+  };
+
+  return normalized;
+};
+
 export const listPlayerAchievements = async (playerId: number) => {
-  return prisma.playerAchievementStatus.findMany({
+  const statuses = await prisma.playerAchievementStatus.findMany({
     where: { playerId },
+  });
+
+  if (statuses.length === 0) {
+    return statuses;
+  }
+
+  const rewardTypes = new Set<string>();
+  const sequences = new Set<number>();
+
+  statuses.forEach((status: any) => {
+    if (status?.typeGid === undefined || status?.typeGid === null) {
+      return;
+    }
+
+    const seq = Number(status.achievementId);
+
+    if (!Number.isFinite(seq)) {
+      return;
+    }
+
+    rewardTypes.add(String(status.typeGid));
+    sequences.add(seq);
+  });
+
+  let achievements: any[] = [];
+
+  if (rewardTypes.size > 0 && sequences.size > 0) {
+    achievements = await prisma.playerAchievement.findMany({
+      where: {
+        rewardType: { in: Array.from(rewardTypes) },
+        seq: { in: Array.from(sequences) },
+      },
+    });
+  }
+
+  const achievementMap = new Map<string, any>();
+
+  achievements.forEach((achievement: any) => {
+    const key = buildAchievementKey(achievement?.rewardType, achievement?.seq);
+    const existing = achievementMap.get(key);
+
+    if (!existing || achievement?.playerId === playerId) {
+      achievementMap.set(key, achievement);
+    }
+  });
+
+  return statuses.map((status: any) => {
+    const achievement = achievementMap.get(
+      buildAchievementKey(status?.typeGid, status?.achievementId),
+    );
+    return normalizeAchievementStatus(status, { achievement });
   });
 };
 
@@ -23,6 +113,23 @@ export const claimAchievement = async (
       return null;
     }
 
+    const rewardType = String(record.typeGid);
+
+    const possibleAchievements = await tx.playerAchievement.findMany({
+      where: {
+        rewardType,
+        seq: record.achievementId,
+      },
+    });
+
+    const achievement =
+      possibleAchievements.find((entry: any) => entry?.playerId === playerId) ??
+      possibleAchievements[0];
+
+    const normalizedRecord = normalizeAchievementStatus(record, {
+      achievement,
+    });
+
     await (tx.playerAchievementStatus as any).update({
       where: {
         playerId_typeGid_achievementId: { playerId, typeGid, achievementId },
@@ -30,18 +137,32 @@ export const claimAchievement = async (
       data: { isGiftReceived: true },
     });
 
-    if ((record.ringBall ?? 0) > 0) {
+    const updatedRecord = {
+      ...normalizedRecord,
+      isGiftReceived: true,
+    };
+
+    const ringBallReward =
+      typeof updatedRecord.ringBall === 'number' ? updatedRecord.ringBall : 0;
+
+    if (ringBallReward > 0) {
       await tx.player.update({
         where: { id: playerId },
-        data: { RingBall: { increment: record.ringBall } },
+        data: { RingBall: { increment: ringBallReward } },
       });
     }
 
-    return record;
+    return updatedRecord;
   });
 
-  if (result && (result as any).itemId) {
-    await addItemToInventory(playerId, (result as any).itemId);
+  const rewardItemId =
+    typeof (result as any)?.itemId === 'number' &&
+    Number.isFinite((result as any).itemId)
+      ? (result as any).itemId
+      : null;
+
+  if (rewardItemId && rewardItemId > 0) {
+    await addItemToInventory(playerId, rewardItemId);
   }
 
   return result;


### PR DESCRIPTION
## Summary
- load linked PlayerAchievement entries alongside player achievement statuses
- normalize reward fields so item drops and ring ball values fall back to the linked achievement data
- ensure claimed rewards update the player's ring ball total and returned status consistently

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68c916a874a08332ad95acba2e564798