### PR TITLE
Add endpoint to fetch friend conversation history

### DIFF
--- a/ReadMe
+++ b/ReadMe
@@ -36,6 +36,7 @@ Body JSON /effect-player/item-level-up:
 GET /api/histories?page=1&pageSize=10 - Lịch sử trận đấu (mặc định 10 bản ghi gần nhất, hỗ trợ phân trang)
 POST /api/draw-reward - Bốc thăm trúng thưởng (body: {"playerId": number})
 POST /api/friend-request - Gửi lời mời kết bạn (body: {"senderId": number, "friendCode": string})
+GET /api/messages/conversation/:playerId/:friendId - Lịch sử trò chuyện giữa hai người chơi
 GET /api/market/items?page=1&itemName=X&level=1&priceOrder=asc&levelOrder=desc - Danh sách vật phẩm bán trên chợ, hỗ trợ lọc và phân trang (mặc định 10 bản ghi mỗi trang)
 
 Body JSON /players/ball-physics:

--- a/src/controllers/friendController.ts
+++ b/src/controllers/friendController.ts
@@ -10,6 +10,7 @@ import {
   getFriendList,
   getPendingFriendRequests,
   getFriendMessages,
+  getConversationHistory,
   searchPlayerById,
 } from '../services/friendService';
 
@@ -171,6 +172,30 @@ export const getFriendMessagesController = async (
       return;
     }
     const result = await getFriendMessages(receiverId);
+    if (result.success) {
+      res.json(result.data);
+      return;
+    }
+    res.status(400).json({ message: result.message });
+  } catch (error: any) {
+    res.status(500).json({ message: error.message });
+  }
+};
+
+export const getConversationHistoryController = async (
+  req: Request,
+  res: Response
+): Promise<void> => {
+  try {
+    const playerId = Number(req.params.playerId);
+    const friendId = Number(req.params.friendId);
+    if (isNaN(playerId) || isNaN(friendId)) {
+      res
+        .status(400)
+        .json({ message: 'Invalid playerId or friendId' });
+      return;
+    }
+    const result = await getConversationHistory(playerId, friendId);
     if (result.success) {
       res.json(result.data);
       return;

--- a/src/routes/friendRoutes.ts
+++ b/src/routes/friendRoutes.ts
@@ -10,6 +10,7 @@ import {
   getFriendListController,
   getPendingFriendRequestsController,
   getFriendMessagesController,
+  getConversationHistoryController,
   deleteFriendMessageController,
   searchPlayerByIdController,
 } from '../controllers/friendController';
@@ -25,6 +26,10 @@ router.post('/receive-items', receiveItemsController);
 router.get('/friend-search/:id', searchPlayerByIdController);
 router.get('/friend-list/:playerId', getFriendListController);
 router.get('/friend-requests/:receiverId', getPendingFriendRequestsController);
+router.get(
+  '/messages/conversation/:playerId/:friendId',
+  getConversationHistoryController
+);
 router.get('/messages/:receiverId', getFriendMessagesController);
 router.delete('/messages/:senderId/:seqMess', deleteFriendMessageController);
 

--- a/src/services/friendService.ts
+++ b/src/services/friendService.ts
@@ -178,6 +178,27 @@ export const getFriendMessages = async (receiverId: number) => {
   }
 };
 
+export const getConversationHistory = async (
+  playerId: number,
+  friendId: number
+) => {
+  try {
+    const messages = await prisma.friendMessage.findMany({
+      where: {
+        OR: [
+          { senderId: playerId, receiverId: friendId },
+          { senderId: friendId, receiverId: playerId },
+        ],
+      },
+      include: { sender: true },
+      orderBy: { createdAt: 'asc' },
+    });
+    return { success: true, data: messages };
+  } catch (error: any) {
+    return { success: false, message: error.message };
+  }
+};
+
 export const sendMessage = async (
   senderId: number,
   receiverId: number,


### PR DESCRIPTION
## Summary
- add a Prisma service helper to gather the full message history between two friends
- expose a controller and route for GET /api/messages/conversation/:playerId/:friendId
- document the new endpoint in the API overview

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cb5cc512cc8332997e430ca6e3003e