### PR TITLE
Add reward player achievement endpoint

### DIFF
--- a/src/controllers/rewardController.ts
+++ b/src/controllers/rewardController.ts
@@ -1,6 +1,7 @@
 import { Request, Response } from 'express';
 import {
   listRewards,
+  listRewardPlayerAchievements,
   refreshRewards as refreshRewardsService,
   claimReward as claimRewardService,
   insertPlayerAchievement as insertPlayerAchievementService,
@@ -33,6 +34,35 @@ export const getRewards = async (req: Request, res: Response) => {
 
     const rewards = await listRewards(rewardType, playerIdNum, dayOfWeekNum);
     res.json(rewards);
+  } catch (error: any) {
+    res.status(500).json({ message: error.message });
+  }
+};
+
+export const getPlayerAchievements = async (req: Request, res: Response) => {
+  try {
+    const playerIdParam = Array.isArray(req.query.playerId)
+      ? req.query.playerId[0]
+      : req.query.playerId;
+    const rewardTypeParam = Array.isArray(req.query.rewardType)
+      ? req.query.rewardType[0]
+      : req.query.rewardType;
+
+    if (typeof rewardTypeParam !== 'string' || typeof playerIdParam !== 'string') {
+      res
+        .status(400)
+        .json({ message: 'Missing or invalid rewardType or playerId' });
+      return;
+    }
+
+    const playerId = Number(playerIdParam);
+    if (Number.isNaN(playerId)) {
+      res.status(400).json({ message: 'Invalid playerId' });
+      return;
+    }
+
+    const achievements = await listRewardPlayerAchievements(playerId, rewardTypeParam);
+    res.json(achievements);
   } catch (error: any) {
     res.status(500).json({ message: error.message });
   }

--- a/src/routes/rewardRoutes.ts
+++ b/src/routes/rewardRoutes.ts
@@ -1,6 +1,7 @@
 import { Router } from 'express';
 import {
   getRewards,
+  getPlayerAchievements,
   refreshRewards,
   claimReward,
   insertPlayerAchievement,
@@ -9,6 +10,7 @@ import {
 const router = Router();
 
 router.get('/rewards', getRewards);
+router.get('/rewards/player-achievements', getPlayerAchievements);
 router.post('/rewards/refresh', refreshRewards);
 router.post('/rewards/claim', claimReward);
 router.post('/rewards/insert', insertPlayerAchievement);

--- a/src/services/rewardService.ts
+++ b/src/services/rewardService.ts
@@ -14,6 +14,10 @@ type RewardRecord = {
   updatedAt: Date | null;
 };
 
+type PlayerAchievementWithStatus = RewardRecord & {
+  rewardType: string;
+};
+
 const buildRewardRecord = (
   status: any | undefined,
   achievement?: any,
@@ -148,6 +152,41 @@ export const listRewards = async (
   return achievements.map((achievement) =>
     buildRewardRecord((achievement as any).statuses?.[0], achievement),
   );
+};
+
+export const listRewardPlayerAchievements = async (
+  playerId: number,
+  rewardType: string,
+): Promise<PlayerAchievementWithStatus[]> => {
+  await ensureBaseAchievements(rewardType, prisma);
+
+  const achievements = await (prisma.playerAchievement as any).findMany({
+    where: { rewardType },
+    orderBy: { seq: 'asc' },
+    include: {
+      statuses: {
+        where: { playerId },
+        select: {
+          isGiftReceived: true,
+          isComplete: true,
+          updatedAt: true,
+        },
+        take: 1,
+      },
+    },
+  });
+
+  return achievements.map((achievement: any) => {
+    const status = achievement?.statuses?.[0];
+    const normalizedStatus = status
+      ? { ...status, achievementId: achievement.seq }
+      : undefined;
+
+    return {
+      rewardType: String(achievement.rewardType ?? rewardType),
+      ...buildRewardRecord(normalizedStatus, achievement),
+    };
+  });
 };
 
 export const insertPlayerAchievement = async (


### PR DESCRIPTION
## Summary
- add a reward service helper that lists achievements for a player and reward type along with status metadata
- expose a controller handler that validates query params and returns the achievements
- register the `/rewards/player-achievements` route to serve the new handler

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cb9e293fb88332a23e1d145a20abab