### PR TITLE
feat: add confirm ad reward endpoint

### DIFF
--- a/src/controllers/rewardController.ts
+++ b/src/controllers/rewardController.ts
@@ -4,6 +4,7 @@ import {
   listRewardPlayerAchievements,
   refreshRewards as refreshRewardsService,
   claimReward as claimRewardService,
+  confirmAdWatch as confirmAdWatchService,
   insertPlayerAchievement as insertPlayerAchievementService,
 } from '../services/rewardService';
 
@@ -125,6 +126,45 @@ export const claimReward = async (req: Request, res: Response) => {
     }
 
     res.json(achievement);
+  } catch (error: any) {
+    res.status(500).json({ message: error.message });
+  }
+};
+
+export const confirmAdWatch = async (req: Request, res: Response) => {
+  try {
+    const { playerId, rewardType, achievementId, locationId } = req.body ?? {};
+
+    const playerIdNum = Number(playerId);
+    if (Number.isNaN(playerIdNum)) {
+      res.status(400).json({ message: 'Missing or invalid parameters' });
+      return;
+    }
+
+    if (typeof rewardType !== 'string') {
+      res.status(400).json({ message: 'Missing or invalid parameters' });
+      return;
+    }
+
+    const rawAchievementId = achievementId ?? locationId;
+    const achievementIdNum = Number(rawAchievementId);
+    if (rawAchievementId === undefined || Number.isNaN(achievementIdNum)) {
+      res.status(400).json({ message: 'Missing or invalid parameters' });
+      return;
+    }
+
+    const reward = await confirmAdWatchService(
+      playerIdNum,
+      rewardType,
+      achievementIdNum,
+    );
+
+    if (!reward) {
+      res.status(404).json({ message: 'Reward status not found' });
+      return;
+    }
+
+    res.json(reward);
   } catch (error: any) {
     res.status(500).json({ message: error.message });
   }

--- a/src/routes/rewardRoutes.ts
+++ b/src/routes/rewardRoutes.ts
@@ -4,6 +4,7 @@ import {
   getPlayerAchievements,
   refreshRewards,
   claimReward,
+  confirmAdWatch,
   insertPlayerAchievement,
 } from '../controllers/rewardController';
 
@@ -13,6 +14,7 @@ router.get('/rewards', getRewards);
 router.get('/rewards/player-achievements', getPlayerAchievements);
 router.post('/rewards/refresh', refreshRewards);
 router.post('/rewards/claim', claimReward);
+router.post('/rewards/confirm-ad', confirmAdWatch);
 router.post('/rewards/insert', insertPlayerAchievement);
 
 export default router;

--- a/src/services/rewardService.ts
+++ b/src/services/rewardService.ts
@@ -359,3 +359,43 @@ export const claimReward = async (
 
   return achievement;
 };
+
+export const confirmAdWatch = async (
+  playerId: number,
+  rewardType: string,
+  achievementId: number,
+) => {
+  const status = await (prisma.playerAchievementStatus as any).findFirst({
+    where: {
+      playerId,
+      typeGid: rewardType,
+      achievementId,
+    },
+    include: {
+      achievement: true,
+    },
+  });
+
+  if (!status) {
+    return null;
+  }
+
+  const updatedStatus = await (prisma.playerAchievementStatus as any).update({
+    where: {
+      playerId_typeGid_achievementId: {
+        playerId,
+        typeGid: rewardType,
+        achievementId,
+      },
+    },
+    data: {
+      isGiftReceived: true,
+      updatedAt: new Date(),
+    },
+    include: {
+      achievement: true,
+    },
+  });
+
+  return buildRewardRecord(updatedStatus, updatedStatus.achievement);
+};


### PR DESCRIPTION
## Summary
- add reward service helper to mark ad-watched rewards as claimed
- expose confirm ad watch controller endpoint with validation and routing

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cbaa7844548332b7881c6e1bcf274d