### PR TITLE
Enforce ad confirmation before claiming rewards

### DIFF
--- a/ReadMe
+++ b/ReadMe
@@ -38,6 +38,8 @@ POST /api/draw-reward - Bốc thăm trúng thưởng (body: {"playerId": number}
 POST /api/friend-request - Gửi lời mời kết bạn (body: {"senderId": number, "friendCode": string})
 GET /api/messages/conversation/:playerId/:friendId - Lịch sử trò chuyện giữa hai người chơi
 GET /api/market/items?page=1&itemName=X&level=1&priceOrder=asc&levelOrder=desc - Danh sách vật phẩm bán trên chợ, hỗ trợ lọc và phân trang (mặc định 10 bản ghi mỗi trang)
+POST /api/rewards/confirm-ad - Xác nhận người chơi đã xem quảng cáo (phải gọi trước khi nhận quà)
+POST /api/rewards/claim - Nhận quà sau khi xác nhận quảng cáo thành công
 
 Body JSON /players/ball-physics:
 {

--- a/src/controllers/rewardController.ts
+++ b/src/controllers/rewardController.ts
@@ -6,6 +6,7 @@ import {
   claimReward as claimRewardService,
   confirmAdWatch as confirmAdWatchService,
   insertPlayerAchievement as insertPlayerAchievementService,
+  RewardClaimError,
 } from '../services/rewardService';
 
 export const getRewards = async (req: Request, res: Response) => {
@@ -127,6 +128,10 @@ export const claimReward = async (req: Request, res: Response) => {
 
     res.json(achievement);
   } catch (error: any) {
+    if (error instanceof RewardClaimError) {
+      res.status(error.statusCode).json({ message: error.message });
+      return;
+    }
     res.status(500).json({ message: error.message });
   }
 };

--- a/src/services/rewardService.ts
+++ b/src/services/rewardService.ts
@@ -1,6 +1,16 @@
 import prisma from '../models/prismaClient';
 import { addItemToInventory } from './playerItemService';
 
+export class RewardClaimError extends Error {
+  statusCode: number;
+
+  constructor(message: string, statusCode: number) {
+    super(message);
+    this.name = 'RewardClaimError';
+    this.statusCode = statusCode;
+  }
+}
+
 const MAX_REWARD_LOCATIONS = 20;
 
 type RewardRecord = {
@@ -321,9 +331,44 @@ export const claimReward = async (
       },
     });
 
-    if (!status || status.isGiftReceived) {
-      return null;
+    if (!status) {
+      throw new RewardClaimError('Reward status not found.', 404);
     }
+
+    if (!status.isGiftReceived) {
+      throw new RewardClaimError(
+        'Reward is not ready to claim. Confirm advertisement before claiming.',
+        400,
+      );
+    }
+
+    if (status.isComplete) {
+      throw new RewardClaimError('Reward has already been claimed.', 409);
+    }
+
+    const limitRaw = status.achievement?.countGif;
+    if (limitRaw !== undefined && limitRaw !== null) {
+      const limit = Number(limitRaw);
+
+      if (Number.isFinite(limit) && limit >= 0) {
+        const completedCount = await (tx.playerAchievementStatus as any).count({
+          where: {
+            typeGid: rewardType,
+            achievementId: locationId,
+            isComplete: true,
+          },
+        });
+
+        if (completedCount >= limit) {
+          throw new RewardClaimError(
+            'Reward claim limit reached for this achievement.',
+            409,
+          );
+        }
+      }
+    }
+
+    const updatedAt = new Date();
 
     await (tx.playerAchievementStatus as any).updateMany({
       where: {
@@ -331,7 +376,7 @@ export const claimReward = async (
         typeGid: rewardType,
         achievementId: locationId,
       },
-      data: { isGiftReceived: true, updatedAt: new Date() },
+      data: { isComplete: true, updatedAt },
     });
 
     const rewardAmount =
@@ -344,7 +389,7 @@ export const claimReward = async (
       });
     }
 
-    return { ...status, isGiftReceived: true };
+    return { ...status, isComplete: true, updatedAt };
   });
 
   if (achievement) {


### PR DESCRIPTION
## Summary
- guard reward claims behind the advertisement confirmation flag and enforce completion limits
- return meaningful HTTP status codes for reward claim failures and document the new confirm-ad prerequisite

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cbabf762a48332b709d4302e689b92