### PR TITLE
feat: add system friend messages endpoint

### DIFF
--- a/src/controllers/friendController.ts
+++ b/src/controllers/friendController.ts
@@ -10,6 +10,7 @@ import {
   getFriendList,
   getPendingFriendRequests,
   getFriendMessages,
+  getSystemMessages,
   getConversationHistory,
   searchPlayerById,
 } from '../services/friendService';
@@ -172,6 +173,27 @@ export const getFriendMessagesController = async (
       return;
     }
     const result = await getFriendMessages(receiverId);
+    if (result.success) {
+      res.json(result.data);
+      return;
+    }
+    res.status(400).json({ message: result.message });
+  } catch (error: any) {
+    res.status(500).json({ message: error.message });
+  }
+};
+
+export const getSystemMessagesController = async (
+  req: Request,
+  res: Response
+): Promise<void> => {
+  try {
+    const receiverId = Number(req.params.receiverId);
+    if (isNaN(receiverId)) {
+      res.status(400).json({ message: 'Invalid receiverId' });
+      return;
+    }
+    const result = await getSystemMessages(receiverId);
     if (result.success) {
       res.json(result.data);
       return;

--- a/src/routes/friendRoutes.ts
+++ b/src/routes/friendRoutes.ts
@@ -10,6 +10,7 @@ import {
   getFriendListController,
   getPendingFriendRequestsController,
   getFriendMessagesController,
+  getSystemMessagesController,
   getConversationHistoryController,
   deleteFriendMessageController,
   searchPlayerByIdController,
@@ -29,6 +30,10 @@ router.get('/friend-requests/:receiverId', getPendingFriendRequestsController);
 router.get(
   '/messages/conversation/:playerId/:friendId',
   getConversationHistoryController
+);
+router.get(
+  '/messages/system/:receiverId',
+  getSystemMessagesController
 );
 router.get('/messages/:receiverId', getFriendMessagesController);
 router.delete('/messages/:senderId/:seqMess', deleteFriendMessageController);

--- a/src/services/friendService.ts
+++ b/src/services/friendService.ts
@@ -184,9 +184,35 @@ ORDER BY a."senderId", a."createdAt" DESC;
     `;
 
     return { success: true, data: latestMessages };
-    
+
   } catch (error: any) {
-    console.error(error); 
+    console.error(error);
+    return { success: false, message: error.message };
+  }
+};
+
+export const getSystemMessages = async (receiverId: number) => {
+  try {
+    const messages = await prisma.friendMessage.findMany({
+      where: {
+        senderId: 0,
+        OR: [{ receiverId }, { receiverId: 0 }],
+      },
+      orderBy: { createdAt: 'desc' },
+      select: {
+        senderId: true,
+        receiverId: true,
+        message: true,
+        status: true,
+        createdAt: true,
+        seqMess: true,
+        itemId: true,
+        seqId: true,
+      },
+    });
+
+    return { success: true, data: messages };
+  } catch (error: any) {
     return { success: false, message: error.message };
   }
 };


### PR DESCRIPTION
## Summary
- add service helper to fetch system friend messages without joining the player table
- expose controller and route for retrieving system messages by receiver id

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68ccd1d6131c8332a399dcdfbe61c312