### PR TITLE
Add system message reward storage and claiming

### DIFF
--- a/prisma/migrations/20250915000000_friend-message-rewards/migration.sql
+++ b/prisma/migrations/20250915000000_friend-message-rewards/migration.sql
@@ -1,0 +1,5 @@
+-- AlterTable
+ALTER TABLE "FriendMessage" ADD COLUMN     "itemRewardId" INTEGER,
+ADD COLUMN     "moneyReward" INTEGER NOT NULL DEFAULT 0,
+ADD COLUMN     "ringBallReward" INTEGER NOT NULL DEFAULT 0;
+

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -250,6 +250,9 @@ model FriendMessage {
   message    String
   itemId     Int?
   seqId      Int?
+  ringBallReward Int    @default(0)
+  moneyReward    Int    @default(0)
+  itemRewardId   Int?
   createdAt  DateTime @default(now())
   sender     Player   @relation("MessagesSent", fields: [senderId], references: [id])
   receiver   Player   @relation("MessagesReceived", fields: [receiverId], references: [id])

--- a/src/controllers/friendController.ts
+++ b/src/controllers/friendController.ts
@@ -12,6 +12,7 @@ import {
   getFriendMessages,
   getSystemMessages,
   getConversationHistory,
+  claimSystemMessageReward,
   searchPlayerById,
 } from '../services/friendService';
 
@@ -302,25 +303,66 @@ export const sendMessageController = async (
     req.body.itemId !== undefined ? Number(req.body.itemId) : undefined;
   const seqId =
     req.body.seqId !== undefined ? Number(req.body.seqId) : undefined;
+  const ringBallRewardRaw = req.body.ringBallReward;
+  const moneyRewardRaw = req.body.moneyReward;
+  const itemRewardIdRaw = req.body.itemRewardId;
+  const ringBallReward =
+    ringBallRewardRaw !== undefined ? Number(ringBallRewardRaw) : undefined;
+  const moneyReward =
+    moneyRewardRaw !== undefined ? Number(moneyRewardRaw) : undefined;
+  let itemRewardId: number | null | undefined;
+  if (itemRewardIdRaw !== undefined) {
+    if (itemRewardIdRaw === null) {
+      itemRewardId = null;
+    } else {
+      const parsed = Number(itemRewardIdRaw);
+      itemRewardId = parsed;
+    }
+  }
 
   if (
     isNaN(senderId) ||
     isNaN(receiverId) ||
     typeof message !== 'string' ||
     (itemId !== undefined && isNaN(itemId)) ||
-    (seqId !== undefined && isNaN(seqId))
+    (seqId !== undefined && isNaN(seqId)) ||
+    (ringBallRewardRaw !== undefined && isNaN(ringBallReward)) ||
+    (moneyRewardRaw !== undefined && isNaN(moneyReward)) ||
+    (itemRewardIdRaw !== undefined &&
+      itemRewardIdRaw !== null &&
+      (itemRewardId === undefined || isNaN(itemRewardId)))
   ) {
     res.status(400).json({ message: 'Invalid parameters' });
     return;
   }
 
   try {
+    const rewardPayload: {
+      ringBallReward?: number;
+      moneyReward?: number;
+      itemRewardId?: number | null;
+    } = {};
+
+    if (ringBallRewardRaw !== undefined) {
+      rewardPayload.ringBallReward = ringBallReward ?? 0;
+    }
+
+    if (moneyRewardRaw !== undefined) {
+      rewardPayload.moneyReward = moneyReward ?? 0;
+    }
+
+    if (itemRewardIdRaw !== undefined) {
+      rewardPayload.itemRewardId =
+        itemRewardIdRaw === null ? null : itemRewardId ?? null;
+    }
+
     const result = await sendMessage(
       senderId,
       receiverId,
       message,
       itemId,
-      seqId
+      seqId,
+      Object.keys(rewardPayload).length > 0 ? rewardPayload : undefined
     );
     if (result.success) {
       res.json(result.data);
@@ -378,6 +420,105 @@ export const receiveItemsController = async (
       return;
     }
     res.status(400).json({ message: result.message });
+  } catch (error: any) {
+    res.status(500).json({ message: error.message });
+  }
+};
+
+export const claimSystemMessageRewardController = async (
+  req: Request,
+  res: Response
+): Promise<void> => {
+  try {
+    const receiverId = Number(req.body.receiverId ?? req.params.receiverId);
+    const seqMessRaw =
+      req.body.seqMess ??
+      req.params.seqMess ??
+      req.body.messageSeq ??
+      req.params.messageSeq;
+    const seqMess = Number(seqMessRaw);
+
+    const ringBallRewardRaw = req.body.ringBallReward;
+    const moneyRewardRaw = req.body.moneyReward;
+    const itemRewardIdRaw = req.body.itemRewardId;
+
+    if (isNaN(receiverId) || seqMessRaw === undefined || isNaN(seqMess)) {
+      res.status(400).json({ message: 'Invalid receiverId or seqMess' });
+      return;
+    }
+
+    const ringBallReward =
+      ringBallRewardRaw !== undefined ? Number(ringBallRewardRaw) : undefined;
+    const moneyReward =
+      moneyRewardRaw !== undefined ? Number(moneyRewardRaw) : undefined;
+    let itemRewardId: number | null | undefined;
+    if (itemRewardIdRaw !== undefined) {
+      if (itemRewardIdRaw === null) {
+        itemRewardId = null;
+      } else {
+        const parsed = Number(itemRewardIdRaw);
+        itemRewardId = parsed;
+      }
+    }
+
+    if (
+      (ringBallRewardRaw !== undefined && isNaN(ringBallReward)) ||
+      (moneyRewardRaw !== undefined && isNaN(moneyReward)) ||
+      (itemRewardIdRaw !== undefined &&
+        itemRewardIdRaw !== null &&
+        (itemRewardId === undefined || isNaN(itemRewardId)))
+    ) {
+      res.status(400).json({ message: 'Invalid reward metadata' });
+      return;
+    }
+
+    const postedRewards: {
+      ringBallReward?: number;
+      moneyReward?: number;
+      itemRewardId?: number | null;
+    } = {};
+
+    if (ringBallRewardRaw !== undefined) {
+      postedRewards.ringBallReward = ringBallReward ?? 0;
+    }
+
+    if (moneyRewardRaw !== undefined) {
+      postedRewards.moneyReward = moneyReward ?? 0;
+    }
+
+    if (itemRewardIdRaw !== undefined) {
+      postedRewards.itemRewardId =
+        itemRewardIdRaw === null ? null : itemRewardId ?? null;
+    }
+
+    const result = await claimSystemMessageReward(
+      receiverId,
+      seqMess,
+      Object.keys(postedRewards).length > 0 ? postedRewards : undefined
+    );
+
+    if (result.success) {
+      res.json(result.data);
+      return;
+    }
+
+    const status = (() => {
+      switch (result.message) {
+        case 'System message not found':
+        case 'Player not found':
+          return 404;
+        case 'Message not available for this player':
+          return 403;
+        case 'Reward already claimed':
+          return 409;
+        case 'Reward mismatch':
+          return 400;
+        default:
+          return 400;
+      }
+    })();
+
+    res.status(status).json({ message: result.message });
   } catch (error: any) {
     res.status(500).json({ message: error.message });
   }

--- a/src/routes/friendRoutes.ts
+++ b/src/routes/friendRoutes.ts
@@ -13,6 +13,7 @@ import {
   getSystemMessagesController,
   getConversationHistoryController,
   deleteFriendMessageController,
+  claimSystemMessageRewardController,
   searchPlayerByIdController,
 } from '../controllers/friendController';
 
@@ -34,6 +35,10 @@ router.get(
 router.get(
   '/messages/system/:receiverId',
   getSystemMessagesController
+);
+router.post(
+  '/messages/system/claim',
+  claimSystemMessageRewardController
 );
 router.get('/messages/:receiverId', getFriendMessagesController);
 router.delete('/messages/:senderId/:seqMess', deleteFriendMessageController);

--- a/src/services/friendService.ts
+++ b/src/services/friendService.ts
@@ -1,4 +1,6 @@
+import type { Prisma } from '@prisma/client';
 import prisma from '../models/prismaClient';
+import { addItemToInventory } from './playerItemService';
 import { getPlayerByListId } from './playerService';
 
 export const searchPlayerById = async (id: number) => {
@@ -208,6 +210,9 @@ export const getSystemMessages = async (receiverId: number) => {
         seqMess: true,
         itemId: true,
         seqId: true,
+        ringBallReward: true,
+        moneyReward: true,
+        itemRewardId: true,
       },
     });
 
@@ -243,7 +248,12 @@ export const sendMessage = async (
   receiverId: number,
   message: string,
   itemId?: number,
-  seqId?: number
+  seqId?: number,
+  rewards?: {
+    ringBallReward?: number;
+    moneyReward?: number;
+    itemRewardId?: number | null;
+  }
 ) => {
   try {
     const messageCount = await prisma.friendMessage.count({
@@ -262,8 +272,27 @@ export const sendMessage = async (
 
     const seqMess = (last?.seqMess ?? 0) + 1;
 
+    const createData: Prisma.FriendMessageUncheckedCreateInput = {
+      senderId,
+      receiverId,
+      message,
+      itemId: itemId ?? null,
+      seqId: seqId ?? null,
+      seqMess,
+    };
+
+    if (senderId === 0) {
+      createData.ringBallReward = rewards?.ringBallReward ?? 0;
+      createData.moneyReward = rewards?.moneyReward ?? 0;
+      const normalizedItemReward = rewards?.itemRewardId ?? null;
+      createData.itemRewardId =
+        normalizedItemReward && normalizedItemReward > 0
+          ? normalizedItemReward
+          : null;
+    }
+
     const msg = await prisma.friendMessage.create({
-      data: { senderId, receiverId, message, itemId, seqId, seqMess },
+      data: createData,
     });
 
     return { success: true, data: msg };
@@ -360,6 +389,129 @@ export const receiveItems = async (
       }
     });
     return { success: true };
+  } catch (error: any) {
+    return { success: false, message: error.message };
+  }
+};
+
+export const claimSystemMessageReward = async (
+  receiverId: number,
+  seqMess: number,
+  postedRewards?: {
+    ringBallReward?: number;
+    moneyReward?: number;
+    itemRewardId?: number | null;
+  }
+) => {
+  try {
+    const result = await prisma.$transaction(async (tx) => {
+      const message = await tx.friendMessage.findFirst({
+        where: {
+          seqMess,
+          OR: [{ receiverId }, { receiverId: 0 }],
+        },
+      });
+
+      if (!message) {
+        throw new Error('System message not found');
+      }
+
+      if (message.senderId !== 0) {
+        throw new Error('Not a system message');
+      }
+
+      if (message.receiverId !== receiverId && message.receiverId !== 0) {
+        throw new Error('Message not available for this player');
+      }
+
+      if (message.status !== 'PENDING') {
+        throw new Error('Reward already claimed');
+      }
+
+      const ringBallReward = message.ringBallReward ?? 0;
+      const moneyReward = message.moneyReward ?? 0;
+      const itemRewardId = message.itemRewardId ?? null;
+
+      if (
+        postedRewards?.ringBallReward !== undefined &&
+        postedRewards.ringBallReward !== ringBallReward
+      ) {
+        throw new Error('Reward mismatch');
+      }
+
+      if (
+        postedRewards?.moneyReward !== undefined &&
+        postedRewards.moneyReward !== moneyReward
+      ) {
+        throw new Error('Reward mismatch');
+      }
+
+      if (postedRewards?.itemRewardId !== undefined) {
+        const normalizedPostedItemId =
+          postedRewards.itemRewardId && postedRewards.itemRewardId > 0
+            ? postedRewards.itemRewardId
+            : null;
+        if (normalizedPostedItemId !== itemRewardId) {
+          throw new Error('Reward mismatch');
+        }
+      }
+
+      const playerUpdateData: Prisma.PlayerUpdateInput = {};
+
+      if (ringBallReward > 0) {
+        playerUpdateData.RingBall = { increment: ringBallReward };
+      }
+
+      if (moneyReward > 0) {
+        playerUpdateData.Money = { increment: moneyReward };
+      }
+
+      const playerExists = await tx.player.findUnique({
+        where: { id: receiverId },
+        select: { id: true },
+      });
+
+      if (!playerExists) {
+        throw new Error('Player not found');
+      }
+
+      if (Object.keys(playerUpdateData).length > 0) {
+        await tx.player.update({
+          where: { id: receiverId },
+          data: playerUpdateData,
+        });
+      }
+
+      if (itemRewardId && itemRewardId > 0) {
+        await addItemToInventory(receiverId, itemRewardId, tx);
+      }
+
+      const updatedMessage = await tx.friendMessage.update({
+        where: {
+          senderId_seqMess: {
+            senderId: message.senderId,
+            seqMess: message.seqMess,
+          },
+        },
+        data: {
+          status: 'READ',
+          ringBallReward: 0,
+          moneyReward: 0,
+          itemRewardId: null,
+        },
+      });
+
+      return {
+        message: updatedMessage,
+        rewards: {
+          ringBallReward,
+          moneyReward,
+          itemRewardId,
+        },
+      };
+    });
+
+    return { success: true, data: result };
   } catch (error: any) {
     return { success: false, message: error.message };
   }

--- a/src/services/playerItemService.ts
+++ b/src/services/playerItemService.ts
@@ -1,3 +1,4 @@
+import type { Prisma } from '@prisma/client';
 import prisma from '../models/prismaClient';
 
 export const buyItem = async (playerId: number, itemId: number) => {
@@ -215,9 +216,10 @@ export const levelUpPlayerItem = async (
 
 export const addItemToInventory = async (
   playerId: number,
-  itemId: number
+  itemId: number,
+  txClient?: Prisma.TransactionClient
 ) => {
-  return prisma.$transaction(async (tx) => {
+  const execute = async (tx: Prisma.TransactionClient) => {
     const lastSeq = await tx.playerItem.findFirst({
       where: {
         playerId,
@@ -238,5 +240,11 @@ export const addItemToInventory = async (
         description: '',
       },
     });
-  });
+  };
+
+  if (txClient) {
+    return execute(txClient);
+  }
+
+  return prisma.$transaction(async (tx) => execute(tx));
 };


### PR DESCRIPTION
## Summary
- extend the FriendMessage model to persist system mail reward metadata and provide a migration script that adds the new columns
- update messaging services and controllers to record reward data on system messages, expose it in system message queries, and add a secure reward-claiming workflow that runs within one transaction
- allow inventory updates to share existing transactions and register a REST endpoint for claiming stored rewards without trusting client-supplied amounts

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68ccea8bb1a88332a42085998f15593d