### PR TITLE
Add delete flags to FriendMessage

### DIFF
--- a/prisma/migrations/20250318000000_friend-message-delete-flags/migration.sql
+++ b/prisma/migrations/20250318000000_friend-message-delete-flags/migration.sql
@@ -1,0 +1,4 @@
+-- AlterTable
+ALTER TABLE "FriendMessage" ADD COLUMN     "isSenderDelete" BOOLEAN NOT NULL DEFAULT false,
+ADD COLUMN     "isReceiverDelete" BOOLEAN NOT NULL DEFAULT false;
+

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -253,6 +253,8 @@ model FriendMessage {
   ringBallReward Int    @default(0)
   moneyReward    Int    @default(0)
   itemRewardId   Int?
+  isSenderDelete   Boolean @default(false)
+  isReceiverDelete Boolean @default(false)
   createdAt  DateTime @default(now())
   sender     Player   @relation("MessagesSent", fields: [senderId], references: [id])
   receiver   Player   @relation("MessagesReceived", fields: [receiverId], references: [id])


### PR DESCRIPTION
## Summary
- add sender and receiver delete flags to the FriendMessage Prisma model with default false values
- add a Prisma migration that creates the corresponding columns on the FriendMessage table

## Testing
- npx prisma generate
- npx tsc --noEmit

------
https://chatgpt.com/codex/tasks/task_e_68d163580f648332bd215d7e7ef11d7d