### PR TITLE
Handle requester-aware friend message deletion

### DIFF
--- a/src/controllers/friendController.ts
+++ b/src/controllers/friendController.ts
@@ -16,6 +16,44 @@ import {
   searchPlayerById,
 } from '../services/friendService';
 
+const parseNumericParam = (...values: unknown[]): number | undefined => {
+  for (const value of values) {
+    if (value === undefined || value === null) {
+      continue;
+    }
+
+    const candidate = Array.isArray(value) ? value[0] : value;
+    if (candidate === undefined || candidate === null) {
+      continue;
+    }
+
+    if (typeof candidate === 'string') {
+      const trimmed = candidate.trim();
+      if (trimmed === '') {
+        continue;
+      }
+      const parsed = Number(trimmed);
+      if (!Number.isNaN(parsed)) {
+        return parsed;
+      }
+      continue;
+    }
+
+    if (typeof candidate === 'number') {
+      if (!Number.isNaN(candidate)) {
+        return candidate;
+      }
+      continue;
+    }
+
+    if (typeof candidate === 'bigint') {
+      return Number(candidate);
+    }
+  }
+
+  return undefined;
+};
+
 export const searchPlayerByIdController = async (
   req: Request,
   res: Response
@@ -275,18 +313,46 @@ export const deleteFriendMessageController = async (
   res: Response
 ): Promise<void> => {
   try {
-    const senderId = Number(req.params.senderId ?? req.body.senderId);
-    const seqMess = Number(req.params.seqMess ?? req.body.seqMess);
-    if (isNaN(senderId) || isNaN(seqMess)) {
-      res.status(400).json({ message: 'Invalid senderId or seqMess' });
+    const requesterId = parseNumericParam(
+      req.params.playerId,
+      req.body.playerId,
+      req.body.requesterId,
+      req.query.playerId,
+      req.query.requesterId
+    );
+    const senderId = parseNumericParam(
+      req.params.senderId,
+      req.body.senderId,
+      req.query.senderId
+    );
+    const seqMess = parseNumericParam(
+      req.params.seqMess,
+      req.body.seqMess,
+      req.query.seqMess
+    );
+
+    if (
+      requesterId === undefined ||
+      senderId === undefined ||
+      seqMess === undefined
+    ) {
+      res
+        .status(400)
+        .json({ message: 'Invalid requesterId, senderId or seqMess' });
       return;
     }
-    const result = await deleteFriendMessage(senderId, seqMess);
+    const result = await deleteFriendMessage(senderId, seqMess, requesterId);
     if (result.success) {
-      res.json({ success: true });
+      res.json({ success: true, data: result.data });
       return;
     }
-    res.status(400).json({ message: result.message });
+    const status =
+      result.message === 'Forbidden'
+        ? 403
+        : result.message === 'Message not found'
+          ? 404
+          : 400;
+    res.status(status).json({ message: result.message });
   } catch (error: any) {
     res.status(500).json({ message: error.message });
   }

--- a/src/routes/friendRoutes.ts
+++ b/src/routes/friendRoutes.ts
@@ -41,6 +41,10 @@ router.post(
   claimSystemMessageRewardController
 );
 router.get('/messages/:receiverId', getFriendMessagesController);
-router.delete('/messages/:senderId/:seqMess', deleteFriendMessageController);
+// DELETE /messages/:playerId/:senderId/:seqMess
+router.delete(
+  '/messages/:playerId/:senderId/:seqMess',
+  deleteFriendMessageController
+);
 
 export default router;

--- a/src/services/friendService.ts
+++ b/src/services/friendService.ts
@@ -519,13 +519,92 @@ export const claimSystemMessageReward = async (
 
 export const deleteFriendMessage = async (
   senderId: number,
-  seqMess: number
+  seqMess: number,
+  requesterId: number
 ) => {
   try {
-    await prisma.friendMessage.delete({
+    const message = await prisma.friendMessage.findUnique({
       where: { senderId_seqMess: { senderId, seqMess } },
+      select: {
+        senderId: true,
+        receiverId: true,
+        isSenderDelete: true,
+        isReceiverDelete: true,
+      },
     });
-    return { success: true };
+
+    if (!message) {
+      return { success: false, message: 'Message not found' };
+    }
+
+    const isSender = requesterId === message.senderId;
+    const isReceiver = requesterId === message.receiverId;
+
+    if (!isSender && !isReceiver) {
+      return { success: false, message: 'Forbidden' };
+    }
+
+    const requesterRole: 'sender' | 'receiver' = isSender ? 'sender' : 'receiver';
+
+    const newSenderDelete = isSender ? true : message.isSenderDelete;
+    const newReceiverDelete = isReceiver ? true : message.isReceiverDelete;
+
+    if (newSenderDelete && newReceiverDelete) {
+      await prisma.friendMessage.delete({
+        where: { senderId_seqMess: { senderId, seqMess } },
+      });
+
+      return {
+        success: true,
+        data: {
+          deleted: true,
+          isSenderDelete: true,
+          isReceiverDelete: true,
+          requesterRole,
+        },
+      };
+    }
+
+    const updateData: Prisma.FriendMessageUpdateInput = {};
+
+    if (isSender && !message.isSenderDelete) {
+      updateData.isSenderDelete = true;
+    }
+
+    if (isReceiver && !message.isReceiverDelete) {
+      updateData.isReceiverDelete = true;
+    }
+
+    if (Object.keys(updateData).length > 0) {
+      const updated = await prisma.friendMessage.update({
+        where: { senderId_seqMess: { senderId, seqMess } },
+        data: updateData,
+        select: {
+          isSenderDelete: true,
+          isReceiverDelete: true,
+        },
+      });
+
+      return {
+        success: true,
+        data: {
+          deleted: false,
+          isSenderDelete: updated.isSenderDelete,
+          isReceiverDelete: updated.isReceiverDelete,
+          requesterRole,
+        },
+      };
+    }
+
+    return {
+      success: true,
+      data: {
+        deleted: false,
+        isSenderDelete: message.isSenderDelete,
+        isReceiverDelete: message.isReceiverDelete,
+        requesterRole,
+      },
+    };
   } catch (error: any) {
     return { success: false, message: error.message };
   }


### PR DESCRIPTION
## Summary
- capture the requesting player on the delete friend message route and controller, including improved validation and status handling
- add reusable numeric parsing for controller inputs and return deletion metadata to callers
- enforce requester permissions in the friend message service while toggling delete flags or removing messages as appropriate

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d1eff3618483328f797c8298cf1713