### PR TITLE
Ensure friend message queries respect deletion flags

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1",
+    "test": "node --require ts-node/register --test tests/friendService.test.ts",
     "build": "tsc",
     "start": "node dist/server.js"
   },

--- a/src/services/friendService.ts
+++ b/src/services/friendService.ts
@@ -182,6 +182,7 @@ export const getFriendMessages = async (receiverId: number) => {
 FROM "FriendMessage" a
 JOIN "Player" b ON a."senderId" = b."id"
 WHERE a."receiverId" = ${receiverId}
+  AND a."isReceiverDelete" = false
 ORDER BY a."senderId", a."createdAt" DESC;
     `;
 
@@ -198,6 +199,7 @@ export const getSystemMessages = async (receiverId: number) => {
     const messages = await prisma.friendMessage.findMany({
       where: {
         senderId: 0,
+        isReceiverDelete: false,
         OR: [{ receiverId }, { receiverId: 0 }],
       },
       orderBy: { createdAt: 'desc' },
@@ -230,8 +232,16 @@ export const getConversationHistory = async (
     const messages = await prisma.friendMessage.findMany({
       where: {
         OR: [
-          { senderId: playerId, receiverId: friendId },
-          { senderId: friendId, receiverId: playerId },
+          {
+            senderId: playerId,
+            receiverId: friendId,
+            isSenderDelete: false,
+          },
+          {
+            senderId: friendId,
+            receiverId: playerId,
+            isReceiverDelete: false,
+          },
         ],
       },
       include: { sender: true },

--- a/tests/friendService.test.ts
+++ b/tests/friendService.test.ts
@@ -1,0 +1,171 @@
+const assert = require('node:assert/strict');
+const { beforeEach, describe, it } = require('node:test');
+
+/**
+ * Simple mock function helper to track calls and override implementations
+ */
+function createMockFunction() {
+  const calls = [];
+  let implementation;
+
+  const mockFn = (...args) => {
+    calls.push(args);
+    if (implementation) {
+      return implementation(...args);
+    }
+    return undefined;
+  };
+
+  mockFn.mock = { calls };
+  mockFn.mockImplementation = (impl) => {
+    implementation = impl;
+  };
+  mockFn.mockResolvedValue = (value) => {
+    implementation = () => Promise.resolve(value);
+  };
+  mockFn.mockReset = () => {
+    calls.length = 0;
+    implementation = undefined;
+  };
+
+  return mockFn;
+}
+
+const queryRawMock = createMockFunction();
+const friendMessageFindManyMock = createMockFunction();
+
+const mockPrisma = {
+  $queryRaw: queryRawMock,
+  friendMessage: {
+    findMany: friendMessageFindManyMock,
+    count: createMockFunction(),
+    findFirst: createMockFunction(),
+    create: createMockFunction(),
+    updateMany: createMockFunction(),
+    findUnique: createMockFunction(),
+    delete: createMockFunction(),
+    update: createMockFunction(),
+  },
+};
+
+const prismaModulePath = require.resolve('../src/models/prismaClient.ts');
+require.cache[prismaModulePath] = {
+  id: prismaModulePath,
+  filename: prismaModulePath,
+  loaded: true,
+  exports: mockPrisma,
+} as any;
+
+const {
+  getConversationHistory,
+  getFriendMessages,
+  getSystemMessages,
+} = require('../src/services/friendService');
+
+describe('friendService visibility filters', () => {
+  beforeEach(() => {
+    queryRawMock.mockReset();
+    friendMessageFindManyMock.mockReset();
+  });
+
+  it('excludes receiver-deleted messages in friend inbox query', async () => {
+    const fakeResult = [
+      {
+        senderId: 2,
+        receiverId: 1,
+        message: 'hello',
+        createdAt: new Date(),
+        status: 'PENDING',
+        seqMess: 1,
+        PlayerName: 'Friend',
+      },
+    ];
+
+    queryRawMock.mockImplementation(async (strings, ...values) => {
+      assert.ok(strings.join(' ').includes('a."isReceiverDelete" = false'));
+      assert.deepEqual(values, [1]);
+      return fakeResult;
+    });
+
+    const result = await getFriendMessages(1);
+
+    assert.equal(result.success, true);
+    assert.deepEqual(result.data, fakeResult);
+    assert.equal(queryRawMock.mock.calls.length, 1);
+  });
+
+  it('omits messages deleted by the requesting player in conversation history', async () => {
+    const conversation = [
+      {
+        senderId: 1,
+        receiverId: 2,
+        message: 'hi',
+        createdAt: new Date(),
+        status: 'READ',
+        seqMess: 1,
+        sender: { id: 1, PlayerName: 'Player' },
+      },
+    ];
+
+    friendMessageFindManyMock.mockResolvedValue(conversation);
+
+    const result = await getConversationHistory(1, 2);
+
+    assert.equal(result.success, true);
+    assert.deepEqual(result.data, conversation);
+    assert.equal(friendMessageFindManyMock.mock.calls.length, 1);
+
+    const args = friendMessageFindManyMock.mock.calls[0][0];
+    const orClauses = args.where.OR;
+
+    assert.deepEqual(
+      orClauses.find(
+        (clause) =>
+          clause.senderId === 1 &&
+          clause.receiverId === 2 &&
+          clause.isSenderDelete === false
+      ),
+      { senderId: 1, receiverId: 2, isSenderDelete: false }
+    );
+
+    assert.deepEqual(
+      orClauses.find(
+        (clause) =>
+          clause.senderId === 2 &&
+          clause.receiverId === 1 &&
+          clause.isReceiverDelete === false
+      ),
+      { senderId: 2, receiverId: 1, isReceiverDelete: false }
+    );
+
+    assert.deepEqual(args.orderBy, { createdAt: 'asc' });
+  });
+
+  it('filters system messages hidden by the receiver', async () => {
+    const systemMessages = [
+      {
+        senderId: 0,
+        receiverId: 1,
+        message: 'system message',
+        status: 'PENDING',
+        createdAt: new Date(),
+        seqMess: 99,
+      },
+    ];
+
+    friendMessageFindManyMock.mockResolvedValue(systemMessages);
+
+    const result = await getSystemMessages(1);
+
+    assert.equal(result.success, true);
+    assert.deepEqual(result.data, systemMessages);
+    assert.equal(friendMessageFindManyMock.mock.calls.length, 1);
+
+    const args = friendMessageFindManyMock.mock.calls[0][0];
+    assert.equal(args.where.isReceiverDelete, false);
+    assert.ok(
+      args.where.OR.some((clause) => clause.receiverId === 1),
+      'Receiver specific clause should be present'
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- stop surfacing friend inbox entries marked deleted by the receiver and ensure system messages respect the same flag
- gate conversation history by sender and receiver deletion flags so each side only sees messages they have not removed
- add node:test coverage for the new visibility rules and update the npm test script to run it

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d1f2f71f7c8332ad45d5f05316c05e