### PR TITLE
Refactor friend message deletion to operate per conversation

### DIFF
--- a/src/controllers/friendController.ts
+++ b/src/controllers/friendController.ts
@@ -314,34 +314,38 @@ export const deleteFriendMessageController = async (
 ): Promise<void> => {
   try {
     const requesterId = parseNumericParam(
-      req.params.playerId,
-      req.body.playerId,
       req.body.requesterId,
+      req.query.requesterId,
+      req.body.playerId,
       req.query.playerId,
-      req.query.requesterId
+      req.params.playerId
     );
-    const senderId = parseNumericParam(
-      req.params.senderId,
-      req.body.senderId,
-      req.query.senderId
+    const partnerId = parseNumericParam(
+      req.params.partnerId,
+      req.body.partnerId,
+      req.query.partnerId
     );
-    const seqMess = parseNumericParam(
-      req.params.seqMess,
-      req.body.seqMess,
-      req.query.seqMess
-    );
+    const routePlayerId = parseNumericParam(req.params.playerId);
 
-    if (
-      requesterId === undefined ||
-      senderId === undefined ||
-      seqMess === undefined
-    ) {
+    if (requesterId === undefined || partnerId === undefined) {
       res
         .status(400)
-        .json({ message: 'Invalid requesterId, senderId or seqMess' });
+        .json({ message: 'Invalid requesterId or partnerId' });
       return;
     }
-    const result = await deleteFriendMessage(senderId, seqMess, requesterId);
+
+    const participants = new Set<number>();
+    if (routePlayerId !== undefined) {
+      participants.add(routePlayerId);
+    }
+    participants.add(partnerId);
+
+    if (!participants.has(requesterId)) {
+      res.status(403).json({ message: 'Forbidden' });
+      return;
+    }
+
+    const result = await deleteFriendMessage(requesterId, partnerId);
     if (result.success) {
       res.json({ success: true, data: result.data });
       return;

--- a/src/routes/friendRoutes.ts
+++ b/src/routes/friendRoutes.ts
@@ -41,9 +41,9 @@ router.post(
   claimSystemMessageRewardController
 );
 router.get('/messages/:receiverId', getFriendMessagesController);
-// DELETE /messages/:playerId/:senderId/:seqMess
+// DELETE /messages/:playerId/:partnerId
 router.delete(
-  '/messages/:playerId/:senderId/:seqMess',
+  '/messages/:playerId/:partnerId',
   deleteFriendMessageController
 );
 

--- a/src/services/friendService.ts
+++ b/src/services/friendService.ts
@@ -528,93 +528,84 @@ export const claimSystemMessageReward = async (
 };
 
 export const deleteFriendMessage = async (
-  senderId: number,
-  seqMess: number,
-  requesterId: number
+  requesterId: number,
+  partnerId: number
 ) => {
   try {
-    const message = await prisma.friendMessage.findUnique({
-      where: { senderId_seqMess: { senderId, seqMess } },
-      select: {
-        senderId: true,
-        receiverId: true,
-        isSenderDelete: true,
-        isReceiverDelete: true,
-      },
+    const result = await prisma.$transaction(async (tx) => {
+      const conversation = await tx.friendMessage.findMany({
+        where: {
+          OR: [
+            { senderId: requesterId, receiverId: partnerId },
+            { senderId: partnerId, receiverId: requesterId },
+          ],
+        },
+        select: {
+          senderId: true,
+          receiverId: true,
+          seqMess: true,
+          isSenderDelete: true,
+          isReceiverDelete: true,
+        },
+      });
+
+      if (conversation.length === 0) {
+        return { success: false as const, message: 'Message not found' };
+      }
+
+      const participates = conversation.some(
+        (message) =>
+          message.senderId === requesterId || message.receiverId === requesterId
+      );
+
+      if (!participates) {
+        return { success: false as const, message: 'Forbidden' };
+      }
+
+      const deleteSent = await tx.friendMessage.deleteMany({
+        where: {
+          senderId: requesterId,
+          receiverId: partnerId,
+          isReceiverDelete: true,
+        },
+      });
+
+      const deleteReceived = await tx.friendMessage.deleteMany({
+        where: {
+          senderId: partnerId,
+          receiverId: requesterId,
+          isSenderDelete: true,
+        },
+      });
+
+      const hideSent = await tx.friendMessage.updateMany({
+        where: {
+          senderId: requesterId,
+          receiverId: partnerId,
+          isSenderDelete: false,
+        },
+        data: { isSenderDelete: true },
+      });
+
+      const hideReceived = await tx.friendMessage.updateMany({
+        where: {
+          senderId: partnerId,
+          receiverId: requesterId,
+          isReceiverDelete: false,
+        },
+        data: { isReceiverDelete: true },
+      });
+
+      return {
+        success: true as const,
+        data: {
+          hiddenCount: hideSent.count + hideReceived.count,
+          hardDeletedCount: deleteSent.count + deleteReceived.count,
+        },
+      };
     });
 
-    if (!message) {
-      return { success: false, message: 'Message not found' };
-    }
-
-    const isSender = requesterId === message.senderId;
-    const isReceiver = requesterId === message.receiverId;
-
-    if (!isSender && !isReceiver) {
-      return { success: false, message: 'Forbidden' };
-    }
-
-    const requesterRole: 'sender' | 'receiver' = isSender ? 'sender' : 'receiver';
-
-    const newSenderDelete = isSender ? true : message.isSenderDelete;
-    const newReceiverDelete = isReceiver ? true : message.isReceiverDelete;
-
-    if (newSenderDelete && newReceiverDelete) {
-      await prisma.friendMessage.delete({
-        where: { senderId_seqMess: { senderId, seqMess } },
-      });
-
-      return {
-        success: true,
-        data: {
-          deleted: true,
-          isSenderDelete: true,
-          isReceiverDelete: true,
-          requesterRole,
-        },
-      };
-    }
-
-    const updateData: Prisma.FriendMessageUpdateInput = {};
-
-    if (isSender && !message.isSenderDelete) {
-      updateData.isSenderDelete = true;
-    }
-
-    if (isReceiver && !message.isReceiverDelete) {
-      updateData.isReceiverDelete = true;
-    }
-
-    if (Object.keys(updateData).length > 0) {
-      const updated = await prisma.friendMessage.update({
-        where: { senderId_seqMess: { senderId, seqMess } },
-        data: updateData,
-        select: {
-          isSenderDelete: true,
-          isReceiverDelete: true,
-        },
-      });
-
-      return {
-        success: true,
-        data: {
-          deleted: false,
-          isSenderDelete: updated.isSenderDelete,
-          isReceiverDelete: updated.isReceiverDelete,
-          requesterRole,
-        },
-      };
-    }
-
-    return {
-      success: true,
-      data: {
-        deleted: false,
-        isSenderDelete: message.isSenderDelete,
-        isReceiverDelete: message.isReceiverDelete,
-        requesterRole,
-      },
-    };
+    return result;
   } catch (error: any) {
     return { success: false, message: error.message };
   }

--- a/tests/friendService.test.ts
+++ b/tests/friendService.test.ts
@@ -32,21 +32,52 @@ function createMockFunction() {
 }
 
 const queryRawMock = createMockFunction();
+const transactionMock = createMockFunction();
 const friendMessageFindManyMock = createMockFunction();
+const friendMessageCountMock = createMockFunction();
+const friendMessageFindFirstMock = createMockFunction();
+const friendMessageCreateMock = createMockFunction();
+const friendMessageUpdateManyMock = createMockFunction();
+const friendMessageFindUniqueMock = createMockFunction();
+const friendMessageDeleteMock = createMockFunction();
+const friendMessageUpdateMock = createMockFunction();
+const friendMessageDeleteManyMock = createMockFunction();
 
 const mockPrisma = {
   $queryRaw: queryRawMock,
+  $transaction: transactionMock,
   friendMessage: {
     findMany: friendMessageFindManyMock,
-    count: createMockFunction(),
-    findFirst: createMockFunction(),
-    create: createMockFunction(),
-    updateMany: createMockFunction(),
-    findUnique: createMockFunction(),
-    delete: createMockFunction(),
-    update: createMockFunction(),
+    count: friendMessageCountMock,
+    findFirst: friendMessageFindFirstMock,
+    create: friendMessageCreateMock,
+    updateMany: friendMessageUpdateManyMock,
+    findUnique: friendMessageFindUniqueMock,
+    delete: friendMessageDeleteMock,
+    update: friendMessageUpdateMock,
+    deleteMany: friendMessageDeleteManyMock,
   },
 };
+
+const resetPrismaMocks = () => {
+  queryRawMock.mockReset();
+  transactionMock.mockReset();
+  friendMessageFindManyMock.mockReset();
+  friendMessageCountMock.mockReset();
+  friendMessageFindFirstMock.mockReset();
+  friendMessageCreateMock.mockReset();
+  friendMessageUpdateManyMock.mockReset();
+  friendMessageFindUniqueMock.mockReset();
+  friendMessageDeleteMock.mockReset();
+  friendMessageUpdateMock.mockReset();
+  friendMessageDeleteManyMock.mockReset();
+
+  transactionMock.mockImplementation(async (callback) => callback(mockPrisma));
+  friendMessageDeleteManyMock.mockImplementation(async () => ({ count: 0 }));
+  friendMessageUpdateManyMock.mockImplementation(async () => ({ count: 0 }));
+};
+
+resetPrismaMocks();
 
 const prismaModulePath = require.resolve('../src/models/prismaClient.ts');
 require.cache[prismaModulePath] = {
@@ -60,12 +91,12 @@ const {
   getConversationHistory,
   getFriendMessages,
   getSystemMessages,
+  deleteFriendMessage,
 } = require('../src/services/friendService');
 
 describe('friendService visibility filters', () => {
   beforeEach(() => {
-    queryRawMock.mockReset();
-    friendMessageFindManyMock.mockReset();
+    resetPrismaMocks();
   });
 
   it('excludes receiver-deleted messages in friend inbox query', async () => {
@@ -167,5 +198,160 @@ describe('friendService visibility filters', () => {
       args.where.OR.some((clause) => clause.receiverId === 1),
       'Receiver specific clause should be present'
     );
+  });
+});
+
+describe('deleteFriendMessage conversation cleanup', () => {
+  beforeEach(() => {
+    resetPrismaMocks();
+  });
+
+  it('hides messages for the requesting player when the partner has not deleted them', async () => {
+    friendMessageFindManyMock.mockResolvedValue([
+      {
+        senderId: 1,
+        receiverId: 2,
+        seqMess: 10,
+        isSenderDelete: false,
+        isReceiverDelete: false,
+      },
+      {
+        senderId: 2,
+        receiverId: 1,
+        seqMess: 11,
+        isSenderDelete: false,
+        isReceiverDelete: false,
+      },
+    ]);
+
+    friendMessageDeleteManyMock.mockImplementation(async (args) => {
+      if (args.where.senderId === 1) {
+        assert.deepEqual(args.where, {
+          senderId: 1,
+          receiverId: 2,
+          isReceiverDelete: true,
+        });
+        return { count: 0 };
+      }
+
+      if (args.where.senderId === 2) {
+        assert.deepEqual(args.where, {
+          senderId: 2,
+          receiverId: 1,
+          isSenderDelete: true,
+        });
+        return { count: 0 };
+      }
+
+      throw new Error('Unexpected deleteMany invocation');
+    });
+
+    friendMessageUpdateManyMock.mockImplementation(async (args) => {
+      if (args.where.senderId === 1) {
+        assert.deepEqual(args.where, {
+          senderId: 1,
+          receiverId: 2,
+          isSenderDelete: false,
+        });
+        assert.deepEqual(args.data, { isSenderDelete: true });
+        return { count: 1 };
+      }
+
+      if (args.where.senderId === 2) {
+        assert.deepEqual(args.where, {
+          senderId: 2,
+          receiverId: 1,
+          isReceiverDelete: false,
+        });
+        assert.deepEqual(args.data, { isReceiverDelete: true });
+        return { count: 1 };
+      }
+
+      throw new Error('Unexpected updateMany invocation');
+    });
+
+    const result = await deleteFriendMessage(1, 2);
+
+    assert.equal(result.success, true);
+    assert.deepEqual(result.data, { hiddenCount: 2, hardDeletedCount: 0 });
+    assert.equal(transactionMock.mock.calls.length, 1);
+    assert.equal(friendMessageDeleteManyMock.mock.calls.length, 2);
+    assert.equal(friendMessageUpdateManyMock.mock.calls.length, 2);
+  });
+
+  it('removes messages once both participants have deleted them', async () => {
+    friendMessageFindManyMock.mockResolvedValue([
+      {
+        senderId: 1,
+        receiverId: 2,
+        seqMess: 20,
+        isSenderDelete: false,
+        isReceiverDelete: true,
+      },
+      {
+        senderId: 2,
+        receiverId: 1,
+        seqMess: 21,
+        isSenderDelete: true,
+        isReceiverDelete: false,
+      },
+    ]);
+
+    let deleteCalls = 0;
+    friendMessageDeleteManyMock.mockImplementation(async (args) => {
+      if (args.where.senderId === 1) {
+        deleteCalls += 1;
+        assert.deepEqual(args.where, {
+          senderId: 1,
+          receiverId: 2,
+          isReceiverDelete: true,
+        });
+        return { count: 1 };
+      }
+
+      if (args.where.senderId === 2) {
+        deleteCalls += 1;
+        assert.deepEqual(args.where, {
+          senderId: 2,
+          receiverId: 1,
+          isSenderDelete: true,
+        });
+        return { count: 1 };
+      }
+
+      throw new Error('Unexpected deleteMany invocation');
+    });
+
+    friendMessageUpdateManyMock.mockImplementation(async (args) => {
+      if (args.where.senderId === 1) {
+        assert.deepEqual(args.where, {
+          senderId: 1,
+          receiverId: 2,
+          isSenderDelete: false,
+        });
+        assert.deepEqual(args.data, { isSenderDelete: true });
+        return { count: 0 };
+      }
+
+      if (args.where.senderId === 2) {
+        assert.deepEqual(args.where, {
+          senderId: 2,
+          receiverId: 1,
+          isReceiverDelete: false,
+        });
+        assert.deepEqual(args.data, { isReceiverDelete: true });
+        return { count: 0 };
+      }
+
+      throw new Error('Unexpected updateMany invocation');
+    });
+
+    const result = await deleteFriendMessage(1, 2);
+
+    assert.equal(result.success, true);
+    assert.deepEqual(result.data, { hiddenCount: 0, hardDeletedCount: 2 });
+    assert.equal(transactionMock.mock.calls.length, 1);
+    assert.equal(deleteCalls, 2);
+    assert.equal(friendMessageUpdateManyMock.mock.calls.length, 2);
   });
 });


### PR DESCRIPTION
## Summary
- change the friend message delete route and controller to work with requester/partner pairs and validate access
- refactor the friend message service to delete or hide conversation messages in a transaction and report hidden vs. hard-deleted counts
- extend the friend service test suite with transaction-aware mocks covering the new deletion lifecycle

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d212d878d48332aa4c534e25e892ae