### PR TITLE
Add pending counts to inventory response

### DIFF
--- a/src/controllers/playerController.ts
+++ b/src/controllers/playerController.ts
@@ -2,6 +2,10 @@
 import { Request, Response, RequestHandler } from 'express';
 import { getPlayerByAccountId, getPlayerByListId, equipPlayerItem } from '../services/playerService';
 import { getInventoryByPlayer } from '../services/itemService';
+import {
+  countPendingFriendMessages,
+  countPendingFriendRequests,
+} from '../services/friendService';
 
 export const getPlayerController = async (req: Request, res: Response) => {
   try {
@@ -39,8 +43,26 @@ export const getInventoryController: RequestHandler = async (
       res.status(400).json({ message: 'Invalid player id' });
       return;
     }
-    const inventory = await getInventoryByPlayer(id);
-    res.json(inventory);
+    const [inventory, newmessage, newreqfriends] = await Promise.all([
+      getInventoryByPlayer(id),
+      countPendingFriendMessages(id),
+      countPendingFriendRequests(id),
+    ]);
+
+    if (!inventory) {
+      res.status(404).json({
+        message: 'Inventory not found',
+        newmessage,
+        newreqfriends,
+      });
+      return;
+    }
+
+    res.json({
+      ...inventory,
+      newmessage,
+      newreqfriends,
+    });
     return;
   } catch (error: any) {
     res.status(500).json({ message: error.message });

--- a/src/routes/playerItemRoutes.ts
+++ b/src/routes/playerItemRoutes.ts
@@ -1,8 +1,10 @@
 import { Router } from 'express';
 import { buyItemController, sellItemController } from '../controllers/playerItemController';
+import { getInventoryController } from '../controllers/playerController';
 
 const router = Router();
 
+router.get('/players/:id/inventory', getInventoryController);
 router.post('/player-item/buy', buyItemController);
 router.post('/player-item/sell', sellItemController);
 

--- a/src/routes/playerRoutes.ts
+++ b/src/routes/playerRoutes.ts
@@ -1,12 +1,10 @@
 // src/routes/playerRoutes.ts
 import { Router } from 'express';
 import * as PlayerController from '../controllers/playerController';
-import { getInventoryController } from '../controllers/playerController';
 const router = Router();
 
 router.get('/player/:id', PlayerController.getPlayerController);
 router.post('/player/by-list-id', PlayerController.getPlayerByIdsController);
-router.get('/players/:id/inventory', getInventoryController);
 router.post('/player/equip', PlayerController.equipItemController);
  
 

--- a/src/services/friendService.ts
+++ b/src/services/friendService.ts
@@ -3,6 +3,18 @@ import prisma from '../models/prismaClient';
 import { addItemToInventory } from './playerItemService';
 import { getPlayerByListId } from './playerService';
 
+export const countPendingFriendMessages = async (receiverId: number) => {
+  return prisma.friendMessage.count({
+    where: { receiverId, status: 'PENDING' },
+  });
+};
+
+export const countPendingFriendRequests = async (receiverId: number) => {
+  return prisma.friendRequest.count({
+    where: { receiverId, status: 'PENDING' },
+  });
+};
+
 export const searchPlayerById = async (id: number) => {
   try {
     const player = await prisma.player.findUnique({


### PR DESCRIPTION
## Summary
- move the player inventory route to the player item routes module
- extend the inventory controller to append pending message and friend request counts to the response
- add friend service helpers that count pending messages and requests for reuse

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d49eba408c83329a0dfccab5dcae7a