### PR TITLE
Fix read message route to accept playerId and seqMess

### DIFF
--- a/src/controllers/friendController.ts
+++ b/src/controllers/friendController.ts
@@ -272,32 +272,23 @@ export const readFriendMessageController = async (
   res: Response
 ): Promise<void> => {
   try {
-    const playerId = Number(req.body.playerId ?? req.params.playerId);
-    const seqMess = Number(req.body.seqMess ?? req.params.seqMess);
-    const receiverIdRaw = req.body.receiverId ?? req.params.receiverId;
-    const receiverId =
-      receiverIdRaw !== undefined ? Number(receiverIdRaw) : undefined;
+    const playerIdRaw = req.body.playerId ?? req.params.playerId;
+    const seqMessRaw = req.body.seqMess ?? req.params.seqMess;
+
+    const playerId = Number(playerIdRaw);
+    const seqMess = Number(seqMessRaw);
 
     if (
-      isNaN(playerId) ||
-      isNaN(seqMess) ||
-      (receiverIdRaw !== undefined && isNaN(receiverId))
+      playerIdRaw === undefined ||
+      seqMessRaw === undefined ||
+      Number.isNaN(playerId) ||
+      Number.isNaN(seqMess)
     ) {
-      res.status(400).json({ message: 'Invalid parameters' });
+      res.status(400).json({ message: 'Invalid playerId or seqMess' });
       return;
     }
 
-    // Optional validation: ensure requester is the intended receiver
-    if (
-      receiverId !== undefined &&
-      Number(req.body.requesterId ?? req.params.requesterId ?? receiverId) !==
-        receiverId
-    ) {
-      res.status(403).json({ message: 'Forbidden' });
-      return;
-    }
-
-    const result = await readMessage(playerId, seqMess, receiverId);
+    const result = await readMessage(playerId, seqMess);
     if (result.success) {
       res.json({ success: true });
       return;

--- a/src/services/friendService.ts
+++ b/src/services/friendService.ts
@@ -324,17 +324,12 @@ export const sendMessage = async (
   }
 };
 
-export const readMessage = async (
-  playerId: number,
-  seqMess: number,
-  receiverId?: number
-) => {
+export const readMessage = async (playerId: number, seqMess: number) => {
   try {
     await prisma.friendMessage.updateMany({
       where: {
-        senderId: playerId,
+        receiverId: playerId,
         seqMess,
-        ...(receiverId !== undefined ? { receiverId } : {}),
       },
       data: { status: 'READ' },
     });


### PR DESCRIPTION
## Summary
- simplify the read friend message controller to accept only the playerId and seqMess inputs
- update the friend message service to mark messages as read for the receiver rather than the sender

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d4b76de7d88332acd553d3b2c8f960