### PR TITLE
Add Firebase auth bridge for UGS tokens

### DIFF
--- a/ReadMe
+++ b/ReadMe
@@ -52,3 +52,23 @@ Body JSON:
   "typeGid": 1,
   "itemId": 5
 }
+
+## Environment configuration for Firebase authentication bridge
+
+- `UGS_PROJECT_ID` (**required**): Unity Gaming Services project identifier used as the JWT audience when verifying UGS player tokens.
+- `FIREBASE_SERVICE_ACCOUNT_KEY` (optional): JSON string representation of a Firebase service account. When omitted, the Firebase Admin SDK will use the default application credentials available in the environment.
+
+The `/auth/ugs-to-firebase` endpoint exchanges a valid UGS player token for a Firebase custom token. Ensure both the Unity and Firebase credentials above are configured before calling this endpoint.
+
+### Manual verification
+
+After setting the environment variables, start the API and exchange a Unity Gaming Services token for a Firebase custom token:
+
+```bash
+curl -X POST \
+  http://localhost:3000/auth/ugs-to-firebase \
+  -H 'Content-Type: application/json' \
+  -d '{"ugsToken":"<UNITY_PLAYER_TOKEN>"}'
+```
+
+The response should be a JSON payload containing the minted Firebase `customToken` that can be supplied to your client applications.

--- a/package.json
+++ b/package.json
@@ -15,6 +15,8 @@
     "@prisma/client": "^6.6.0",
     "dotenv": "^16.5.0",
     "express": "^5.1.0",
+    "firebase-admin": "^13.0.1",
+    "jose": "^5.10.0",
     "prisma": "^6.6.0",
     "socket.io": "^4.8.1",
     "ws": "^8.18.3"

--- a/src/app.ts
+++ b/src/app.ts
@@ -14,6 +14,7 @@ import accountRoutes from './routes/accountRoutes';
 import friendRoutes from './routes/friendRoutes';
 import rewardRoutes from './routes/rewardRoutes';
 import achievementRoutes from './routes/achievementRoutes';
+import authRoutes from './routes/authRoutes';
 
 const app = express();
 
@@ -36,6 +37,7 @@ app.use('/api', accountRoutes);
 app.use('/api', friendRoutes);
 app.use('/api', rewardRoutes);
 app.use('/api', achievementRoutes);
+app.use(authRoutes);
 
 // KHÔNG CÒN BẤT KỲ ĐOẠN app.listen() hay new WebSocket.Server() nào ở đây
 

--- a/src/config/firebaseAdmin.ts
+++ b/src/config/firebaseAdmin.ts
@@ -1,0 +1,27 @@
+import admin from 'firebase-admin';
+import dotenv from 'dotenv';
+
+dotenv.config();
+
+const serviceAccountJson = process.env.FIREBASE_SERVICE_ACCOUNT_KEY;
+
+if (!admin.apps.length) {
+  try {
+    if (serviceAccountJson) {
+      const serviceAccount = JSON.parse(serviceAccountJson) as admin.ServiceAccount;
+
+      admin.initializeApp({
+        credential: admin.credential.cert(serviceAccount),
+      });
+    } else {
+      admin.initializeApp({
+        credential: admin.credential.applicationDefault(),
+      });
+    }
+  } catch (error) {
+    console.error('Failed to initialize Firebase Admin SDK', error);
+    throw error;
+  }
+}
+
+export default admin;

--- a/src/controllers/authController.ts
+++ b/src/controllers/authController.ts
@@ -1,0 +1,56 @@
+import { Request, Response } from 'express';
+import { createRemoteJWKSet, jwtVerify } from 'jose';
+
+import admin from '../config/firebaseAdmin';
+
+const unityIssuer = 'https://player-auth.services.api.unity.com';
+const jwksUri = new URL('https://player-auth.services.api.unity.com/.well-known/jwks.json');
+const jwks = createRemoteJWKSet(jwksUri);
+
+export const ugsToFirebase = async (req: Request, res: Response): Promise<void> => {
+  const { ugsToken } = req.body ?? {};
+
+  if (typeof ugsToken !== 'string' || !ugsToken.trim()) {
+    res.status(400).json({ message: 'ugsToken is required.' });
+    return;
+  }
+
+  const projectId = process.env.UGS_PROJECT_ID;
+
+  if (!projectId) {
+    console.error('UGS_PROJECT_ID environment variable is not configured.');
+    res.status(500).json({ message: 'UGS project ID is not configured.' });
+    return;
+  }
+
+  let verificationResult;
+
+  try {
+    verificationResult = await jwtVerify(ugsToken, jwks, {
+      issuer: unityIssuer,
+      audience: projectId,
+    });
+  } catch (error) {
+    console.error('Failed to verify UGS token', error);
+    res.status(401).json({ message: 'Invalid UGS token.' });
+    return;
+  }
+
+  const playerId = verificationResult.payload.sub;
+
+  if (typeof playerId !== 'string' || !playerId.trim()) {
+    console.error('UGS token payload is missing subject (playerId).');
+    res.status(400).json({ message: 'UGS token missing subject claim.' });
+    return;
+  }
+
+  const uid = `ugs:${playerId}`;
+
+  try {
+    const customToken = await admin.auth().createCustomToken(uid);
+    res.json({ customToken });
+  } catch (error) {
+    console.error('Failed to create Firebase custom token', error);
+    res.status(500).json({ message: 'Failed to mint Firebase custom token.' });
+  }
+};

--- a/src/routes/authRoutes.ts
+++ b/src/routes/authRoutes.ts
@@ -1,0 +1,8 @@
+import { Router } from 'express';
+import { ugsToFirebase } from '../controllers/authController';
+
+const router = Router();
+
+router.post('/auth/ugs-to-firebase', ugsToFirebase);
+
+export default router;


### PR DESCRIPTION
## Summary
- add dependencies required to verify Unity Gaming Services JWTs and mint Firebase custom tokens
- configure Firebase Admin initialization and expose a controller/route to exchange UGS tokens for Firebase tokens
- document the environment variables and curl workflow for the new authentication bridge

## Testing
- npm run build *(fails: missing firebase-admin / jose modules until dependencies can be installed)*

------
https://chatgpt.com/codex/tasks/task_e_68d779989a8c83329999bf4e315205c6