### PR TITLE
Load auth controller environment configuration from .env

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,4 @@
+UGS_PROJECT_ID=xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
+UGS_ENVIRONMENT_NAME=production
+UNITY_ISSUER=https://player-auth.services.api.unity.com
+UNITY_JWKS_URL=https://player-auth.services.api.unity.com/.well-known/jwks.json

--- a/src/controllers/authController.ts
+++ b/src/controllers/authController.ts
@@ -1,3 +1,4 @@
+import 'dotenv/config';
 import { Request, Response } from 'express';
 import { createRemoteJWKSet, jwtVerify } from 'jose';
 import admin from '../config/firebaseAdmin';
@@ -9,10 +10,12 @@ import admin from '../config/firebaseAdmin';
  * - Mints a Firebase Custom Token for the player
  */
 
-const UNITY_ISSUER = process.env.UNITY_ISSUER || 'https://player-auth.services.api.unity.com';
-const UNITY_JWKS_URL = process.env.UNITY_JWKS_URL || 'https://player-auth.services.api.unity.com/.well-known/jwks.json';
-const UGS_PROJECT_ID = process.env.UGS_PROJECT_ID;
-const UGS_ENVIRONMENT_NAME = process.env.UGS_ENVIRONMENT_NAME || 'production';
+const {
+  UNITY_ISSUER = 'https://player-auth.services.api.unity.com',
+  UNITY_JWKS_URL = 'https://player-auth.services.api.unity.com/.well-known/jwks.json',
+  UGS_PROJECT_ID,
+  UGS_ENVIRONMENT_NAME = 'production',
+} = process.env;
 
 // Fail fast if project id is missing
 if (!UGS_PROJECT_ID) {


### PR DESCRIPTION
## Summary
- add a committed `.env` file that documents required Unity authentication environment variables
- import dotenv in the auth controller and destructure configuration values from `process.env`
- continue guarding against missing project id while using environment-backed constants for responses

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d782b4dd588332a1ce1fd604715a4a