### PR TITLE
Delete system message history after claiming reward

### DIFF
--- a/src/services/friendService.ts
+++ b/src/services/friendService.ts
@@ -504,23 +504,25 @@ export const claimSystemMessageReward = async (
         await addItemToInventory(receiverId, itemRewardId, tx);
       }
 
-      const updatedMessage = await tx.friendMessage.update({
+      await tx.friendMessage.delete({
         where: {
           senderId_seqMess: {
             senderId: message.senderId,
             seqMess: message.seqMess,
           },
         },
-        data: {
-          status: 'READ',
-          ringBallReward: 0,
-          moneyReward: 0,
-          itemRewardId: null,
-        },
       });
 
+      const sanitizedMessage = {
+        ...message,
+        status: 'READ',
+        ringBallReward: 0,
+        moneyReward: 0,
+        itemRewardId: null,
+      };
+
       return {
-        message: updatedMessage,
+        message: sanitizedMessage,
         rewards: {
           ringBallReward,
           moneyReward,


### PR DESCRIPTION
## Summary
- remove the system friend message from storage after a reward claim
- return a sanitized message payload with zeroed reward metadata for clients

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68da17c6c2408332a855c497f53bce02